### PR TITLE
README: Link to the releases page instead of master.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Software Release
 --------------------------------------------------------------------------
-| Dynamixel SDK Version | 1.X | 2.X | 3.X ([Download](https://github.com/ROBOTIS-GIT/DynamixelSDK/archive/master.zip)) |
+| Dynamixel SDK Version | 1.X | 2.X | 3.X ([Download](https://github.com/ROBOTIS-GIT/DynamixelSDK/releases)) |
 | ------------- | ------------- | ------------- | ------------- |
 | Release date| 2010.05.16 | 2015.02.10 | 2016.03.08 |
 | Latest version released |||3.4.1|


### PR DESCRIPTION
Most users probably will want to download the latest released version instead of the current development branch, which might be unstable.