### PR TITLE
Removed stray fprintf output in C++ source

### DIFF
--- a/c++/src/dynamixel_sdk/group_bulk_read.cpp
+++ b/c++/src/dynamixel_sdk/group_bulk_read.cpp
@@ -170,7 +170,6 @@ int GroupBulkRead::rxPacket()
     result = ph_->readRx(port_, length_list_[id], data_list_[id]);
     if (result != COMM_SUCCESS)
     {
-      fprintf(stderr, "[GroupBulkRead::rxPacket] ID %d result : %d !!!!!!!!!!\n", id, result);
       return result;
     }
   }


### PR DESCRIPTION
This output should be handled upstream, like in the rest of the code
