### PR TITLE
Make installed linux library symlinks relative to most versioned target.

### DIFF
--- a/c++/build/linux32/Makefile
+++ b/c++/build/linux32/Makefile
@@ -14,10 +14,11 @@ MAJ_VERSION = 2
 MIN_VERSION = 0
 REV_VERSION = 0
 
-TARGET      = libdxl_x86_cpp.so
-TARGET1     = $(TARGET).$(MAJ_VERSION)
-TARGET2     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION)
-TARGET3     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+LIBRARY_NAME = libdxl_x86_cpp.so
+TARGET       = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+TARGET1      = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION)
+TARGET2      = $(LIBRARY_NAME).$(MAJ_VERSION)
+TARGET3      = $(LIBRARY_NAME)
 
 CHK_DIR_EXISTS = test -d
 PRINT       = echo
@@ -78,9 +79,9 @@ install: $(TARGET)
     # copy the binaries into the lib directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/lib || $(MKDIR) $(INSTALL_ROOT)/lib
 	-$(CP) "./$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
 
     # copy the headers into the include directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/include || $(MKDIR) $(INSTALL_ROOT)/include

--- a/c++/build/linux64/Makefile
+++ b/c++/build/linux64/Makefile
@@ -14,10 +14,11 @@ MAJ_VERSION = 2
 MIN_VERSION = 0
 REV_VERSION = 0
 
-TARGET      = libdxl_x64_cpp.so
-TARGET1     = $(TARGET).$(MAJ_VERSION)
-TARGET2     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION)
-TARGET3     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+LIBRARY_NAME = libdxl_x64_cpp.so
+TARGET       = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+TARGET1      = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION)
+TARGET2      = $(LIBRARY_NAME).$(MAJ_VERSION)
+TARGET3      = $(LIBRARY_NAME)
 
 CHK_DIR_EXISTS = test -d
 PRINT       = echo
@@ -78,9 +79,9 @@ install: $(TARGET)
     # copy the binaries into the lib directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/lib || $(MKDIR) $(INSTALL_ROOT)/lib
 	-$(CP) "./$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
 
     # copy the headers into the include directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/include || $(MKDIR) $(INSTALL_ROOT)/include

--- a/c++/build/linux_sbc/Makefile
+++ b/c++/build/linux_sbc/Makefile
@@ -14,10 +14,11 @@ MAJ_VERSION = 2
 MIN_VERSION = 0
 REV_VERSION = 0
 
-TARGET      = libdxl_sbc_cpp.so
-TARGET1     = $(TARGET).$(MAJ_VERSION)
-TARGET2     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION)
-TARGET3     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+LIBRARY_NAME = libdxl_sbc_cpp.so
+TARGET       = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+TARGET1      = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION)
+TARGET2      = $(LIBRARY_NAME).$(MAJ_VERSION)
+TARGET3      = $(LIBRARY_NAME)
 
 CHK_DIR_EXISTS = test -d
 PRINT       = echo
@@ -77,9 +78,9 @@ install: $(TARGET)
     # copy the binaries into the lib directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/lib || $(MKDIR) $(INSTALL_ROOT)/lib
 	-$(CP) "./$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
 
     # copy the headers into the include directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/include || $(MKDIR) $(INSTALL_ROOT)/include

--- a/c/build/linux32/Makefile
+++ b/c/build/linux32/Makefile
@@ -14,10 +14,11 @@ MAJ_VERSION = 2
 MIN_VERSION = 0
 REV_VERSION = 0
 
-TARGET      = libdxl_x86_c.so
-TARGET1     = $(TARGET).$(MAJ_VERSION)
-TARGET2     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION)
-TARGET3     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+LIBRARY_NAME = libdxl_x86_c.so
+TARGET       = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+TARGET1      = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION)
+TARGET2      = $(LIBRARY_NAME).$(MAJ_VERSION)
+TARGET3      = $(LIBRARY_NAME)
 
 CHK_DIR_EXISTS = test -d
 PRINT       = echo
@@ -78,9 +79,9 @@ install: $(TARGET)
     # copy the binaries into the lib directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/lib || $(MKDIR) $(INSTALL_ROOT)/lib
 	-$(CP) "./$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
 
     # copy the headers into the include directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/include || $(MKDIR) $(INSTALL_ROOT)/include

--- a/c/build/linux64/Makefile
+++ b/c/build/linux64/Makefile
@@ -14,10 +14,11 @@ MAJ_VERSION = 2
 MIN_VERSION = 0
 REV_VERSION = 0
 
-TARGET      = libdxl_x64_c.so
-TARGET1     = $(TARGET).$(MAJ_VERSION)
-TARGET2     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION)
-TARGET3     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+LIBRARY_NAME = libdxl_x64_c.so
+TARGET       = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+TARGET1      = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION)
+TARGET2      = $(LIBRARY_NAME).$(MAJ_VERSION)
+TARGET3      = $(LIBRARY_NAME)
 
 CHK_DIR_EXISTS = test -d
 PRINT       = echo
@@ -78,9 +79,9 @@ install: $(TARGET)
     # copy the binaries into the lib directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/lib || $(MKDIR) $(INSTALL_ROOT)/lib
 	-$(CP) "./$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
 
     # copy the headers into the include directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/include || $(MKDIR) $(INSTALL_ROOT)/include

--- a/c/build/linux_sbc/Makefile
+++ b/c/build/linux_sbc/Makefile
@@ -14,10 +14,11 @@ MAJ_VERSION = 2
 MIN_VERSION = 0
 REV_VERSION = 0
 
-TARGET      = libdxl_sbc_c.so
-TARGET1     = $(TARGET).$(MAJ_VERSION)
-TARGET2     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION)
-TARGET3     = $(TARGET).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+LIBRARY_NAME = libdxl_sbc_c.so
+TARGET       = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION).$(REV_VERSION)
+TARGET1      = $(LIBRARY_NAME).$(MAJ_VERSION).$(MIN_VERSION)
+TARGET2      = $(LIBRARY_NAME).$(MAJ_VERSION)
+TARGET3      = $(LIBRARY_NAME)
 
 CHK_DIR_EXISTS = test -d
 PRINT       = echo
@@ -77,9 +78,9 @@ install: $(TARGET)
     # copy the binaries into the lib directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/lib || $(MKDIR) $(INSTALL_ROOT)/lib
 	-$(CP) "./$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
-	-$(SYMLINK) "$(INSTALL_ROOT)/lib/$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET1)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET2)"
+	-$(SYMLINK) "$(TARGET)" "$(INSTALL_ROOT)/lib/$(TARGET3)"
 
     # copy the headers into the include directory
 	@$(CHK_DIR_EXISTS) $(INSTALL_ROOT)/include || $(MKDIR) $(INSTALL_ROOT)/include


### PR DESCRIPTION
This PR does two things:
* It makes the symlinks to the installed library relative.
* It makes the most versioned target the real one, and the other ones symlinks.

The first one is to make it easier to package the software for a package manager. Often you want to "install" to a staging directory which is then compressed and turned into a system package. If the symlinks are absolute to that staging location, the installed package will have broken symlinks.

The second change is because it allows installing multiple versions without breaking the others. If the least versioned target is the real one, the more versioned targets will incorrectly be updated if someone installs a different version that overwrites `libdxl_*.so`.