### PR TITLE
Fix misleading indentation warning in group_sync_read.c

### DIFF
--- a/c/src/dynamixel_sdk/group_sync_read.c
+++ b/c/src/dynamixel_sdk/group_sync_read.c
@@ -257,15 +257,15 @@ void groupSyncReadRxPacket(int group_num)
     if (groupData[group_num].data_list[data_num].id == NOT_USED_ID)
       continue;
 
-      packetData[port_num].data_read
-        = (uint8_t *)realloc(packetData[port_num].data_read, groupData[group_num].data_length * sizeof(uint8_t));
+    packetData[port_num].data_read
+      = (uint8_t *)realloc(packetData[port_num].data_read, groupData[group_num].data_length * sizeof(uint8_t));
 
-      readRx(groupData[group_num].port_num, groupData[group_num].protocol_version, groupData[group_num].data_length);
-      if (packetData[port_num].communication_result != COMM_SUCCESS)
-        return;
+    readRx(groupData[group_num].port_num, groupData[group_num].protocol_version, groupData[group_num].data_length);
+    if (packetData[port_num].communication_result != COMM_SUCCESS)
+      return;
 
-      for (c = 0; c < groupData[group_num].data_length; c++)
-        groupData[group_num].data_list[data_num].data[c] = packetData[port_num].data_read[c];
+    for (c = 0; c < groupData[group_num].data_length; c++)
+      groupData[group_num].data_list[data_num].data[c] = packetData[port_num].data_read[c];
   }
 
   if (packetData[port_num].communication_result == COMM_SUCCESS)


### PR DESCRIPTION
GCC 6 warns about misleading indentation: code that appears to be guarded by an if-statement based on indentation, but actually isn't. That caused the warning below to appear with GCC 6. This PR adjust the indentation to fix the warning.

```
gcc -O2 -O3 -DLINUX -D_GNU_SOURCE -Wall -c -I../../include -m64 -fPIC -g -c ../../src/dynamixel_sdk/group_sync_read.c -o .objects/group_sync_read.o
../../src/dynamixel_sdk/group_sync_read.c: In function ‘groupSyncReadRxPacket’:
../../src/dynamixel_sdk/group_sync_read.c:257:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (groupData[group_num].data_list[data_num].id == NOT_USED_ID)
     ^~
../../src/dynamixel_sdk/group_sync_read.c:260:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
       packetData[port_num].data_read
```
