### PR TITLE
Fix CMake for Mac ROS compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 
 # HTML
 *.html
+
+# Mac
+.DS_Store

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -35,17 +35,22 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_library(dynamixel_sdk
-  src/dynamixel_sdk/packet_handler.cpp
-  src/dynamixel_sdk/protocol1_packet_handler.cpp
-  src/dynamixel_sdk/protocol2_packet_handler.cpp
-  src/dynamixel_sdk/group_sync_read.cpp
-  src/dynamixel_sdk/group_sync_write.cpp
-  src/dynamixel_sdk/group_bulk_read.cpp
-  src/dynamixel_sdk/group_bulk_write.cpp
-  src/dynamixel_sdk/port_handler.cpp
-  src/dynamixel_sdk/port_handler_linux.cpp
-)
+  add_library(dynamixel_sdk
+    src/dynamixel_sdk/packet_handler.cpp
+    src/dynamixel_sdk/protocol1_packet_handler.cpp
+    src/dynamixel_sdk/protocol2_packet_handler.cpp
+    src/dynamixel_sdk/group_sync_read.cpp
+    src/dynamixel_sdk/group_sync_write.cpp
+    src/dynamixel_sdk/group_bulk_read.cpp
+    src/dynamixel_sdk/group_bulk_write.cpp
+    src/dynamixel_sdk/port_handler.cpp
+  )
+if(APPLE)
+  target_sources(dynamixel_sdk PRIVATE src/dynamixel_sdk/port_handler_mac.cpp)
+else()
+  target_sources(dynamixel_sdk PRIVATE src/dynamixel_sdk/port_handler_linux.cpp)
+endif()
+
 add_dependencies(dynamixel_sdk ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(dynamixel_sdk ${catkin_LIBRARIES})
 


### PR DESCRIPTION
The CmakeLists.txt for C++/ROS used the port_handler_linux.cpp. But when compiled on Mac this needs to be changed to port_handler_mac.cpp. I added an if clause to check if we are on Mac. I did not make a check for Windows, as I do not have a way of testing it on Windows.