### PR TITLE
[CI] Add Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+    recipients:
+      - gm130s@gmail.com
+env:
+  matrix:
+    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic"   PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: USE_DEB=true  ROS_DISTRO="kinetic"   PRERELEASE=true
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - .ci_config/travis.sh
+


### PR DESCRIPTION
Same as https://github.com/ROBOTIS-GIT/dynamixel-workbench/pull/78, I suggest utilizing CI into your project.

(Just reiterating from https://github.com/ROBOTIS-GIT/dynamixel-workbench/pull/78) [ROS offers ways](http://wiki.ros.org/CIs) to simplify the usage of CI. In this PR, I'm suggesting to use [industrial_ci](http://wiki.ros.org/industrial_ci). It is a set of scripts for CI on ROS. The simple config file in this PR enables CI to run on Travis CI for this repo, including [ROS pre-release test](http://wiki.ros.org/bloom/Tutorials/PrereleaseTest) that is recommended for released packages.
Contrary to its name it works for non-industrial ROS packages as well, btw.

If this looks good, can any admin enable Travis for this repo at https://travis-ci.org/profile/ROBOTIS-GIT?

Caveat is that not all platforms are tested, e.g. issues like https://github.com/ROBOTIS-GIT/DynamixelSDK/issues/136 that seems only to be happening with Debian Jessie isn't caught.