### PR TITLE
Support getting of time on MacOSX/XCode versions that don't support `…

### DIFF
--- a/c/src/dynamixel_sdk/port_handler_mac.c
+++ b/c/src/dynamixel_sdk/port_handler_mac.c
@@ -42,6 +42,11 @@
 #include <sys/time.h>
 #include <sys/ioctl.h>
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 #include "port_handler_mac.h"
 
 #define LATENCY_TIMER   8  // msec (USB latency timer) [was changed from 4 due to the Ubuntu update 16.04.2]
@@ -207,7 +212,17 @@ uint8_t isPacketTimeoutMac(int port_num)
 double getCurrentTimeMac()
 {
   struct timespec tv;
+#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  tv.tv_sec = mts.tv_sec;
+  tv.tv_nsec = mts.tv_nsec;
+#else
   clock_gettime(CLOCK_REALTIME, &tv);
+#endif
   return ((double)tv.tv_sec*1000.0 + (double)tv.tv_nsec*0.001*0.001);
 }
 


### PR DESCRIPTION
…clock_gettime`