### PR TITLE
Added method for reading multiple bytes for sync read

### DIFF
--- a/c++/include/dynamixel_sdk/group_sync_read.h
+++ b/c++/include/dynamixel_sdk/group_sync_read.h
@@ -155,6 +155,16 @@ class WINDECLSPEC GroupSyncRead
   uint32_t    getData     (uint8_t id, uint16_t address, uint16_t data_length);
 
   ////////////////////////////////////////////////////////////////////////////////
+  /// @brief The function that gets multiple bytes of the data which might be received by GroupSyncRead::rxPacket or GroupSyncRead::txRxPacket
+  /// @param id Dynamixel ID
+  /// @param address start address of the data for read
+  /// @data_length Length of the data for read
+  /// @data vector of bytes where the read bytes are saved into
+  /// @return true if success
+  ////////////////////////////////////////////////////////////////////////////////
+  bool getMultipleWordsData(uint8_t id, uint16_t address, uint16_t data_length, std::vector<uint8_t> *data);
+
+  ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that gets the error which might be received by GroupSyncRead::rxPacket or GroupSyncRead::txRxPacket
   /// @param id Dynamixel ID
   /// @error error of Dynamixel

--- a/c++/src/dynamixel_sdk/group_sync_read.cpp
+++ b/c++/src/dynamixel_sdk/group_sync_read.cpp
@@ -202,7 +202,6 @@ bool GroupSyncRead::getMultipleWordsData(uint8_t id, uint16_t address, uint16_t 
 
     data->clear();
     for(int i = 0; i < data_length;i++){ //todo maybe memcpy for performance
-        //ROS_WARN("id: %d, len: %d, data: %d", id, data_length, data_list_[id][address - start_address_ + i] );
         data->push_back(data_list_[id][address - start_address_ + i]);
     }
 

--- a/c++/src/dynamixel_sdk/group_sync_read.cpp
+++ b/c++/src/dynamixel_sdk/group_sync_read.cpp
@@ -196,6 +196,20 @@ uint32_t GroupSyncRead::getData(uint8_t id, uint16_t address, uint16_t data_leng
   }
 }
 
+bool GroupSyncRead::getMultipleWordsData(uint8_t id, uint16_t address, uint16_t data_length, std::vector<uint8_t> *data){
+    if (isAvailable(id, address, data_length) == false)
+        return false;
+
+    data->clear();
+    for(int i = 0; i < data_length;i++){ //todo maybe memcpy for performance
+        //ROS_WARN("id: %d, len: %d, data: %d", id, data_length, data_list_[id][address - start_address_ + i] );
+        data->push_back(data_list_[id][address - start_address_ + i]);
+    }
+
+    return true;
+}
+
+
 bool GroupSyncRead::getError(uint8_t id, uint8_t* error)
 {
   // TODO : check protocol version, last_result_, data_list


### PR DESCRIPTION
Hello,
this method gives the user the chance to read multiple registers with a single sync read.
I already mentioned why this is useful here:
https://github.com/ROBOTIS-GIT/dynamixel-workbench/pull/97
