### PR TITLE
Added missing header file for reset and factory_reset examples

### DIFF
--- a/c++/example/protocol1.0/reset/reset.cpp
+++ b/c++/example/protocol1.0/reset/reset.cpp
@@ -32,6 +32,7 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include <fcntl.h>
 #include <termios.h>
+#include <unistd.h>
 #define STDIN_FILENO 0
 #elif defined(_WIN32) || defined(_WIN64)
 #include <conio.h>

--- a/c++/example/protocol2.0/factory_reset/factory_reset.cpp
+++ b/c++/example/protocol2.0/factory_reset/factory_reset.cpp
@@ -32,6 +32,7 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include <fcntl.h>
 #include <termios.h>
+#include <unistd.h>
 #define STDIN_FILENO 0
 #elif defined(_WIN32) || defined(_WIN64)
 #include <conio.h>

--- a/c/example/protocol1.0/reset/reset.c
+++ b/c/example/protocol1.0/reset/reset.c
@@ -33,6 +33,7 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include <fcntl.h>
 #include <termios.h>
+#include <unistd.h>
 #define STDIN_FILENO 0
 #elif defined(_WIN32) || defined(_WIN64)
 #include <conio.h>

--- a/c/example/protocol2.0/factory_reset/factory_reset.c
+++ b/c/example/protocol2.0/factory_reset/factory_reset.c
@@ -33,6 +33,7 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include <fcntl.h>
 #include <termios.h>
+#include <unistd.h>
 #define STDIN_FILENO 0
 #elif defined(_WIN32) || defined(_WIN64)
 #include <conio.h>


### PR DESCRIPTION
unistd was missing in the examples, so compilation was failing 