### PR TITLE
Removed busy wait for rx packet in group sync read

### DIFF
--- a/c++/src/dynamixel_sdk/protocol2_packet_handler.cpp
+++ b/c++/src/dynamixel_sdk/protocol2_packet_handler.cpp
@@ -30,6 +30,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
+
 
 #define TXPACKET_MAX_LEN    (4*1024)
 #define RXPACKET_MAX_LEN    (4*1024)
@@ -415,6 +417,7 @@ int Protocol2PacketHandler::rxPacket(PortHandler *port, uint8_t *rxpacket)
         break;
       }
     }
+    usleep(1000);
   }
   port->is_using_ = false;
 


### PR DESCRIPTION
I added a usleep in the loop that waits for rx packets. This lowers CPU usage significantly (35% -> 5%).