### PR TITLE
Fixes to C# Win64 project

### DIFF
--- a/c#/protocol_combined/win64/protocol_combined/dynamixel.cs
+++ b/c#/protocol_combined/win64/protocol_combined/dynamixel.cs
@@ -21,9 +21,9 @@ using System.Runtime.InteropServices;
 
 namespace dynamixel_sdk
 {
-  class dynamixel
+  unsafe class dynamixel
   {
-    const string dll_path = "../../../../../../../../c/build/win64/output/dxl_x64_c.dll";
+    const string dll_path = "dxl_x64_c.dll";
 
     #region PortHandler
     [DllImport(dll_path)]
@@ -46,18 +46,18 @@ namespace dynamixel_sdk
     [DllImport(dll_path)]
     public static extern int    getBaudRate         (int port_num);
 
-    #ifdef __linux__
+    #if __linux__
     [DllImport(dll_path)]
     public static extern int    getBytesAvailable   (int port_num);
     #endif
 
     [DllImport(dll_path)]
-    public static extern int    readPort            (int port_num, uint8_t *packet, int length);
+    public static extern int    readPort            (int port_num, Byte *packet, int length);
     [DllImport(dll_path)]
-    public static extern int    writePort           (int port_num, uint8_t *packet, int length);
+    public static extern int    writePort           (int port_num, Byte* packet, int length);
 
     [DllImport(dll_path)]
-    public static extern void   setPacketTimeout    (int port_num, uint16_t packet_length);
+    public static extern void   setPacketTimeout    (int port_num, UInt16 packet_length);
     [DllImport(dll_path)]
     public static extern void   setPacketTimeoutMSec(int port_num, double msec);
     [DllImport(dll_path)]

--- a/c#/protocol_combined/win64/protocol_combined/protocol_combined.csproj
+++ b/c#/protocol_combined/win64/protocol_combined/protocol_combined.csproj
@@ -50,6 +50,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -70,6 +71,11 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>robocopy "..\..\..\..\..\..\..\c\build\Win64\output" . *.dll /njh /njs /ndl /nc /ns /MIR
+set rce=%25errorlevel%25
+if not %25rce%25==1 exit %25rce%25 else exit 0</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
These fixes also need to be applied to the Win32 project
Ideally C# should generate an AnyCPU .NET assembly