### PR TITLE
modified address range check logic of GroupSyncRead::isAvailable

### DIFF
--- a/c++/src/dynamixel_sdk/group_sync_read.cpp
+++ b/c++/src/dynamixel_sdk/group_sync_read.cpp
@@ -168,7 +168,7 @@ bool GroupSyncRead::isAvailable(uint8_t id, uint16_t address, uint16_t data_leng
   if (ph_->getProtocolVersion() == 1.0 || last_result_ == false || data_list_.find(id) == data_list_.end())
     return false;
 
-  if (address < start_address_ || start_address_ + data_length_ - data_length < address)
+  if (address < start_address_ || start_address_ + data_length_ < address - data_length)
     return false;
 
   return true;

--- a/c/src/dynamixel_sdk/group_sync_read.c
+++ b/c/src/dynamixel_sdk/group_sync_read.c
@@ -291,7 +291,7 @@ uint8_t groupSyncReadIsAvailable(int group_num, uint8_t id, uint16_t address, ui
   if (groupData[group_num].protocol_version == 1 || groupData[group_num].last_result == False || groupData[group_num].data_list[data_num].id == NOT_USED_ID)
     return False;
 
-  if (address < groupData[group_num].start_address || groupData[group_num].start_address + groupData[group_num].data_length - data_length < address) {
+  if (address < groupData[group_num].start_address || groupData[group_num].start_address + groupData[group_num].data_length < address - data_length) {
     return False;
   }
   return True;

--- a/python/src/dynamixel_sdk/group_sync_read.py
+++ b/python/src/dynamixel_sdk/group_sync_read.py
@@ -122,7 +122,7 @@ class GroupSyncRead:
         if self.ph.getProtocolVersion() == 1.0 or self.last_result is False or dxl_id not in self.data_dict:
             return False
 
-        if (address < self.start_address) or (self.start_address + self.data_length - data_length < address):
+        if (address < self.start_address) or (self.start_address + self.data_length < address - data_length):
             return False
 
         return True

--- a/ros/src/dynamixel_sdk/group_sync_read.cpp
+++ b/ros/src/dynamixel_sdk/group_sync_read.cpp
@@ -168,7 +168,7 @@ bool GroupSyncRead::isAvailable(uint8_t id, uint16_t address, uint16_t data_leng
   if (ph_->getProtocolVersion() == 1.0 || last_result_ == false || data_list_.find(id) == data_list_.end())
     return false;
 
-  if (address < start_address_ || start_address_ + data_length_ - data_length < address)
+  if (address < start_address_ || start_address_ + data_length_ < address - data_length)
     return false;
 
   return true;

--- a/ros/src/dynamixel_sdk/group_sync_read.py
+++ b/ros/src/dynamixel_sdk/group_sync_read.py
@@ -122,7 +122,7 @@ class GroupSyncRead:
         if self.ph.getProtocolVersion() == 1.0 or self.last_result is False or dxl_id not in self.data_dict:
             return False
 
-        if (address < self.start_address) or (self.start_address + self.data_length - data_length < address):
+        if (address < self.start_address) or (self.start_address + self.data_length < address - data_length):
             return False
 
         return True


### PR DESCRIPTION

This is a solution to the issue below.
[groupSyncRead getdata failed with DynamixelPro](https://github.com/ROBOTIS-GIT/dynamixel-workbench/issues/234)

I think the reason for the error is the logic of address range check.
I understood the logic to make sure that the acquired data is in the following range.
start_address_ < address < data_length_ + data_length
```
e.g.
start_address_:611
address:621
data_length_:10
data_length:2
611 < 621 < 611 + 10 + 2
```
Please review.
