### PR TITLE
Fixing ROS import for dynamixel_sdk by adding imports to __init__.py

### DIFF
--- a/ros/src/dynamixel_sdk/__init__.py
+++ b/ros/src/dynamixel_sdk/__init__.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+################################################################################
+# Copyright 2017 ROBOTIS CO., LTD.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Author: Ryu Woon Jung (Leon)
+
+from .port_handler import *
+from .packet_handler import *
+from .group_sync_read import *
+from .group_sync_write import *
+from .group_bulk_read import *
+from .group_bulk_write import *


### PR DESCRIPTION
Dropping the repo in `src/` folder of a ROS workspace and running `catkin_make` is supposed to install the `dynamixel_sdk` package. However, because the `__init__.py` in `ros/src/dynamixel_sdk/` was empty, the objects inside (`PortHandler`, `PacketHandler`, etc.) couldn't be accessed:

![Sep07::085147](https://user-images.githubusercontent.com/8888789/64448143-97065500-d10f-11e9-9dc6-0fb725b95259.png)


After adding the imports to `__init__.py` (just copied the file from the `python/` folder), I'm able to import the objects correctly:

![Sep07::085309](https://user-images.githubusercontent.com/8888789/64448150-9a99dc00-d10f-11e9-9080-cda1763168cb.png)
