### PR TITLE
Use select to reduce CPU usage.

### DIFF
--- a/dynamixel_sdk/src/dynamixel_sdk/protocol1_packet_handler.cpp
+++ b/dynamixel_sdk/src/dynamixel_sdk/protocol1_packet_handler.cpp
@@ -441,8 +441,13 @@ int Protocol1PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
   uint8_t txpacket[8]         = {0};
   uint8_t *rxpacket           = (uint8_t *)malloc(RXPACKET_MAX_LEN);//(length+6);
 
-  if (id >= BROADCAST_ID)
+  if (rxpacket == NULL)
+    return result;
+
+  if (id >= BROADCAST_ID) {
+    free(rxpacket);
     return COMM_NOT_AVAILABLE;
+  }
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = 4;

--- a/dynamixel_sdk/src/dynamixel_sdk/protocol2_packet_handler.cpp
+++ b/dynamixel_sdk/src/dynamixel_sdk/protocol2_packet_handler.cpp
@@ -712,8 +712,10 @@ int Protocol2PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
   if (rxpacket == NULL)
     return result;
   
-  if (id >= BROADCAST_ID)
+  if (id >= BROADCAST_ID) {
+    free(rxpacket);
     return COMM_NOT_AVAILABLE;
+  }
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH_L]      = 7;


### PR DESCRIPTION
Since the file descriptor to the COM port is non-blocking,
use select to sleep for as long as we need to get data.  This
reduces CPU usage quite a lot.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>