### PR TITLE
included setRS485 method in port_handler_linux.h

### DIFF
--- a/c++/include/dynamixel_sdk/port_handler_linux.h
+++ b/c++/include/dynamixel_sdk/port_handler_linux.h
@@ -22,7 +22,7 @@
 #ifndef DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_LINUX_PORTHANDLERLINUX_H_
 #define DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_LINUX_PORTHANDLERLINUX_H_
 
-
+#include <linux/serial.h>
 #include "port_handler.h"
 
 namespace dynamixel
@@ -163,6 +163,14 @@ class PortHandlerLinux : public PortHandler
   /// @description The function checks whether current time is passed by the time of packet timeout from the time set by PortHandlerLinux::setPacketTimeout().
   ////////////////////////////////////////////////////////////////////////////////
   bool    isPacketTimeout();
+
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief The function configures the current port in RS485 mode
+  /// @description The function tries to configure the current port in RS485 mode.
+  ////////////////////////////////////////////////////////////////////////////////
+  bool    setRS485(struct serial_rs485 *rs485conf);
+
 };
 
 }

--- a/c++/src/dynamixel_sdk/port_handler_linux.cpp
+++ b/c++/src/dynamixel_sdk/port_handler_linux.cpp
@@ -280,4 +280,16 @@ int PortHandlerLinux::getCFlagBaud(int baudrate)
   }
 }
 
+
+bool PortHandlerLinux::setRS485(struct serial_rs485 *rs485conf)
+{
+  if (ioctl(socket_fd_, TIOCSRS485, rs485conf) < 0)
+  {
+    printf("[PortHandlerLinux::setRS485] TIOCSRS485 failed!\n");
+    return false;
+  }
+  return true;
+}
+
+
 #endif

--- a/ros/include/dynamixel_sdk/port_handler_linux.h
+++ b/ros/include/dynamixel_sdk/port_handler_linux.h
@@ -22,7 +22,7 @@
 #ifndef DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_LINUX_PORTHANDLERLINUX_H_
 #define DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_LINUX_PORTHANDLERLINUX_H_
 
-
+#include <linux/serial.h>
 #include "port_handler.h"
 
 namespace dynamixel
@@ -163,6 +163,14 @@ class PortHandlerLinux : public PortHandler
   /// @description The function checks whether current time is passed by the time of packet timeout from the time set by PortHandlerLinux::setPacketTimeout().
   ////////////////////////////////////////////////////////////////////////////////
   bool    isPacketTimeout();
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief The function configures the current port in RS485 mode
+  /// @description The function tries to configure the current port in RS485 mode.
+  ////////////////////////////////////////////////////////////////////////////////
+  bool    setRS485(struct serial_rs485 *rs485conf);
+
+
 };
 
 }

--- a/ros/src/dynamixel_sdk/port_handler_linux.cpp
+++ b/ros/src/dynamixel_sdk/port_handler_linux.cpp
@@ -280,4 +280,16 @@ int PortHandlerLinux::getCFlagBaud(int baudrate)
   }
 }
 
+
+bool PortHandlerLinux::setRS485(struct serial_rs485 *rs485conf)
+{
+  if (ioctl(socket_fd_, TIOCSRS485, rs485conf) < 0)
+  {
+    printf("[PortHandlerLinux::setRS485] TIOCSRS485 failed!\n");
+    return false;
+  }
+  return true;
+}
+
+
 #endif


### PR DESCRIPTION
Added method `setRS485` in the `PortHandlerLinux` in order to have the ability to configure the port with RS485 protocol. Since `socket_fd_` is private, the controller (or robot using the port) does not have access to the port socket to perform the configuration.

Code was updated only `c++` section and `ros` directories.

Caller of `setRS485()` needs to provide an instantiated `struct serial_rs485` with the desired configuration. Therefore it can be used to set or reset the RS845 configuration of the port. RTS behaviour and delays can also be configured using this parameter.