### PR TITLE
Add CMSIS port handler

### DIFF
--- a/c/include/dynamixel_sdk/dynamixel_sdk.h
+++ b/c/include/dynamixel_sdk/dynamixel_sdk.h
@@ -19,6 +19,9 @@
 #ifndef DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_DYNAMIXELSDK_C_H_
 #define DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_DYNAMIXELSDK_C_H_
 
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
 
 #include "robotis_def.h"
 #include "group_bulk_read.h"
@@ -27,6 +30,10 @@
 #include "group_sync_write.h"
 #include "packet_handler.h"
 #include "port_handler.h"
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
 
 
 #endif /* DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_DYNAMIXELSDK_C_H_ */

--- a/c/include/dynamixel_sdk/packet_handler.h
+++ b/c/include/dynamixel_sdk/packet_handler.h
@@ -79,7 +79,7 @@ typedef struct
   uint8_t     *broadcast_ping_id_list;
 }PacketData;
 
-PacketData *packetData;
+extern PacketData *packetData;
 
 WINDECLSPEC void        packetHandler       ();
 

--- a/c/include/dynamixel_sdk/port_handler.h
+++ b/c/include/dynamixel_sdk/port_handler.h
@@ -44,8 +44,8 @@
 
 static const int DEFAULT_BAUDRATE = 57600;
 
-int     g_used_port_num;
-uint8_t    *g_is_using;
+extern int g_used_port_num;
+extern uint8_t *g_is_using;
 
 WINDECLSPEC int     portHandler             (const char *port_name);
 

--- a/c/include/dynamixel_sdk/port_handler.h
+++ b/c/include/dynamixel_sdk/port_handler.h
@@ -29,6 +29,8 @@
   #else
   #define WINDECLSPEC __declspec(dllimport)
   #endif
+#elif defined(__USE_CMSIS)
+#define WINDECLSPEC
 #endif
 
 #ifdef __GNUC__

--- a/c/include/dynamixel_sdk/port_handler_cmsis.h
+++ b/c/include/dynamixel_sdk/port_handler_cmsis.h
@@ -1,0 +1,100 @@
+/** Port handler for a CMSIS USART driver.
+ *
+ * The user must provide the following:
+ *   1. RTE_Device.h - Run-time environment file for your implementation.
+ *   2. getCurrentTimeCMSIS() - timing interface.
+ *   3. enableTransmitCMSIS() - set hardware for transmit
+ *   4. disableTransmitCMSIS() - set hardware for receive
+ *
+ * @warning CMSIS implementation *must* support buffered receive.
+ *
+ * This is usually enabled in your "RTE_Device.h" file, for example:
+ *   #define USART_RX_BUFFER_LEN 256
+ *   #define USART0_RX_BUFFER_ENABLE 1
+ *
+ * For more information on CMSIS see:
+ * https://github.com/ARM-software/CMSIS_5
+ *
+ * @file port_handler_cmsis.h
+ * @author Wilkins White
+ */
+
+/*******************************************************************************
+* Copyright 2017 ROBOTIS CO., LTD.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_CMSIS_PORTHANDLERCMSIS_C_H_
+#define DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_CMSIS_PORTHANDLERCMSIS_C_H_
+
+#include "port_handler.h"
+#include "Driver_USART.h"
+#include "RTE_Device.h"
+
+#if !(RTE_USART0 || RTE_USART1 || RTE_USART2 || RTE_USART3 || RTE_USART4 || RTE_USART5)
+#error "No USART drivers found"
+#endif
+
+#if RTE_USART0
+  extern ARM_DRIVER_USART Driver_USART0;
+#endif
+
+#if RTE_USART1
+  extern ARM_DRIVER_USART Driver_USART1;
+#endif
+
+#if RTE_USART2
+  extern ARM_DRIVER_USART Driver_USART2;
+#endif
+
+#if RTE_USART3
+  extern ARM_DRIVER_USART Driver_USART3;
+#endif
+
+#if RTE_USART4
+  extern ARM_DRIVER_USART Driver_USART4;
+#endif
+
+#if RTE_USART5
+  extern ARM_DRIVER_USART Driver_USART5;
+#endif
+
+extern double getCurrentTimeCMSIS();
+extern void enableTransmitCMSIS();
+extern void disableTransmitCMSIS();
+
+int portHandlerCMSIS            (const char *port_name);
+
+uint8_t openPortCMSIS           (int port_num);
+void    closePortCMSIS          (int port_num);
+void    clearPortCMSIS          (int port_num);
+
+void    setPortNameCMSIS        (int port_num, const char *port_name);
+char   *getPortNameCMSIS        (int port_num);
+
+uint8_t setBaudRateCMSIS        (int port_num, const int baudrate);
+int     getBaudRateCMSIS        (int port_num);
+
+int     getBytesAvailableCMSIS  (int port_num);
+
+int     readPortCMSIS           (int port_num, uint8_t *packet, int length);
+int     writePortCMSIS          (int port_num, uint8_t *packet, int length);
+
+void    setPacketTimeoutCMSIS     (int port_num, uint16_t packet_length);
+void    setPacketTimeoutMSecCMSIS (int port_num, double msec);
+uint8_t isPacketTimeoutCMSIS      (int port_num);
+
+double getTimeSinceStartCMSIS     (int port_num);
+
+#endif /* DYNAMIXEL_SDK_INCLUDE_DYNAMIXEL_SDK_CMSIS_PORTHANDLERCMSIS_C_H_ */

--- a/c/include/dynamixel_sdk/robotis_def.h
+++ b/c/include/dynamixel_sdk/robotis_def.h
@@ -25,9 +25,13 @@ typedef signed short int    int16_t;
 typedef signed int          int32_t;
 #endif
 
+#if defined(__USE_CMSIS)
+#include <stdint.h>
+#else
 typedef unsigned char       uint8_t;
 typedef unsigned short int  uint16_t;
 typedef unsigned int        uint32_t;
+#endif
 
 #define True                1
 #define False               0

--- a/c/src/dynamixel_sdk/group_bulk_read.c
+++ b/c/src/dynamixel_sdk/group_bulk_read.c
@@ -26,6 +26,8 @@
 #elif defined(_WIN32) || defined(_WIN64)
 #define WINDLLEXPORT
 #include "group_bulk_read.h"
+#elif defined(__USE_CMSIS)
+#include "group_bulk_read.h"
 #endif
 
 typedef struct

--- a/c/src/dynamixel_sdk/group_bulk_write.c
+++ b/c/src/dynamixel_sdk/group_bulk_write.c
@@ -25,6 +25,8 @@
 #elif defined(_WIN32) || defined(_WIN64)
 #define WINDLLEXPORT
 #include "group_bulk_write.h"
+#elif defined(__USE_CMSIS)
+#include "group_bulk_write.h"
 #endif
 
 typedef struct

--- a/c/src/dynamixel_sdk/group_sync_read.c
+++ b/c/src/dynamixel_sdk/group_sync_read.c
@@ -25,6 +25,8 @@
 #elif defined(_WIN32) || defined(_WIN64)
 #define WINDLLEXPORT
 #include "group_sync_read.h"
+#elif defined(__USE_CMSIS)
+#include "group_sync_read.h"
 #endif
 
 typedef struct

--- a/c/src/dynamixel_sdk/group_sync_write.c
+++ b/c/src/dynamixel_sdk/group_sync_write.c
@@ -25,6 +25,8 @@
 #elif defined(_WIN32) || defined(_WIN64)
 #define WINDLLEXPORT
 #include "group_sync_write.h"
+#elif defined(__USE_CMSIS)
+#include "group_sync_write.h"
 #endif
 
 typedef struct

--- a/c/src/dynamixel_sdk/packet_handler.c
+++ b/c/src/dynamixel_sdk/packet_handler.c
@@ -33,6 +33,8 @@
 #include "protocol2_packet_handler.h"
 #endif
 
+PacketData *packetData = NULL;
+
 void packetHandler()
 {
   int port_num;

--- a/c/src/dynamixel_sdk/packet_handler.c
+++ b/c/src/dynamixel_sdk/packet_handler.c
@@ -31,6 +31,10 @@
 #include "packet_handler.h"
 #include "protocol1_packet_handler.h"
 #include "protocol2_packet_handler.h"
+#elif defined(__USE_CMSIS)
+#include "packet_handler.h"
+#include "protocol1_packet_handler.h"
+#include "protocol2_packet_handler.h"
 #endif
 
 PacketData *packetData = NULL;

--- a/c/src/dynamixel_sdk/port_handler.c
+++ b/c/src/dynamixel_sdk/port_handler.c
@@ -16,8 +16,12 @@
 
 /* Author: Ryu Woon Jung (Leon) */
 
-#if defined(__linux__)
 #include "port_handler.h"
+
+int g_used_port_num = 0;
+uint8_t *g_is_using;
+
+#if defined(__linux__)
 #include "port_handler_linux.h"
 
 int     portHandler         (const char *port_name) { return portHandlerLinux(port_name); }
@@ -42,7 +46,6 @@ void    setPacketTimeoutMSec(int port_num, double msec) { setPacketTimeoutMSecLi
 uint8_t isPacketTimeout     (int port_num) { return isPacketTimeoutLinux(port_num); }
 
 #elif defined(__APPLE__)
-#include "port_handler.h"
 #include "port_handler_mac.h"
 
 int     portHandler         (const char *port_name) { return portHandlerMac(port_name); }
@@ -68,7 +71,6 @@ uint8_t isPacketTimeout     (int port_num) { return isPacketTimeoutMac(port_num)
 
 #elif defined(_WIN32) || defined(_WIN64)
 #define WINDLLEXPORT
-#include "port_handler.h"
 #include "port_handler_windows.h"
 
 int     portHandler         (const char *port_name) { return portHandlerWindows(port_name); }

--- a/c/src/dynamixel_sdk/port_handler.c
+++ b/c/src/dynamixel_sdk/port_handler.c
@@ -92,4 +92,26 @@ void    setPacketTimeout    (int port_num, uint16_t packet_length) { setPacketTi
 void    setPacketTimeoutMSec(int port_num, double msec) { setPacketTimeoutMSecWindows(port_num, msec); }
 uint8_t isPacketTimeout     (int port_num) { return isPacketTimeoutWindows(port_num); }
 
+#elif defined(__USE_CMSIS)
+#include "port_handler_cmsis.h"
+
+int     portHandler         (const char *port_name) { return portHandlerCMSIS(port_name); }
+
+uint8_t openPort            (int port_num) { return openPortCMSIS(port_num); }
+void    closePort           (int port_num) { closePortCMSIS(port_num); }
+void    clearPort           (int port_num) { clearPortCMSIS(port_num); }
+
+void    setPortName         (int port_num, const char *port_name) { setPortNameCMSIS(port_num, port_name); }
+char   *getPortName         (int port_num) { return getPortNameCMSIS(port_num); }
+
+uint8_t setBaudRate         (int port_num, const int baudrate) { return setBaudRateCMSIS(port_num, baudrate); }
+int     getBaudRate         (int port_num) { return getBaudRateCMSIS(port_num); }
+
+int     readPort            (int port_num, uint8_t *packet, int length) { return readPortCMSIS(port_num, packet, length); }
+int     writePort           (int port_num, uint8_t *packet, int length) { return writePortCMSIS(port_num, packet, length); }
+
+void    setPacketTimeout    (int port_num, uint16_t packet_length) { setPacketTimeoutCMSIS(port_num, packet_length); }
+void    setPacketTimeoutMSec(int port_num, double msec) { setPacketTimeoutMSecCMSIS(port_num, msec); }
+uint8_t isPacketTimeout     (int port_num) { return isPacketTimeoutCMSIS(port_num); }
+
 #endif

--- a/c/src/dynamixel_sdk/port_handler_cmsis.c
+++ b/c/src/dynamixel_sdk/port_handler_cmsis.c
@@ -177,6 +177,9 @@ int getBaudRateCMSIS(int port_num)
 
 int readPortCMSIS(int port_num, uint8_t *packet, int length)
 {
+  if(!packet || length == 0)
+      return 0;
+
   if (!portData[port_num].rx_busy)
   {
     // Start receive
@@ -195,6 +198,9 @@ int readPortCMSIS(int port_num, uint8_t *packet, int length)
 
 int writePortCMSIS(int port_num, uint8_t *packet, int length)
 {
+  if(!packet || length == 0)
+      return 0;
+
   enableTransmitCMSIS();
   portData[port_num].driver->Send(packet, length);
 

--- a/c/src/dynamixel_sdk/port_handler_cmsis.c
+++ b/c/src/dynamixel_sdk/port_handler_cmsis.c
@@ -1,0 +1,241 @@
+/*******************************************************************************
+* Copyright 2017 ROBOTIS CO., LTD.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/* Author: Wilkins White */
+
+#if defined(__USE_CMSIS)
+
+#include "port_handler_cmsis.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define NAME_SIZE 16
+#define LATENCY_TIMER 10
+
+typedef struct
+{
+  const char *name;
+  ARM_DRIVER_USART *driver;
+} Device;
+
+static Device deviceLookup[] = {
+#if RTE_USART0
+ {"USART0", &Driver_USART0 },
+#endif
+
+#if RTE_USART1
+ {"USART1", &Driver_USART1 },
+#endif
+
+#if RTE_USART2
+ {"USART2", &Driver_USART2 },
+#endif
+
+#if RTE_USART3
+ {"USART3", &Driver_USART3 },
+#endif
+
+#if RTE_USART4
+ {"USART4", &Driver_USART4 },
+#endif
+
+#if RTE_USART5
+ {"USART5", &Driver_USART5 },
+#endif
+
+ { NULL, NULL },
+};
+
+typedef struct
+{
+  ARM_DRIVER_USART *driver;
+
+  int     baudrate;
+  char    port_name[NAME_SIZE];
+
+  double  packet_start_time;
+  double  packet_timeout;
+  double  tx_time_per_byte;
+  uint8_t rx_busy;
+} PortData;
+
+static PortData *portData = NULL;
+
+int portHandlerCMSIS(const char *port_name)
+{
+  int port_num = 0;
+
+  if (portData == NULL)
+  {
+    g_used_port_num = 1;
+    portData = (PortData *)calloc(g_used_port_num, sizeof(PortData));
+    g_is_using = (uint8_t*)calloc(g_used_port_num, sizeof(uint8_t));
+  }
+  else
+  {
+    // Check for duplicate port initialization
+    for (int i = 0; i < g_used_port_num; i++)
+    {
+      if (strcmp(portData[i].port_name, port_name) == 0)
+        return -1;
+    }
+
+    // Increase the port count
+    port_num = g_used_port_num;
+
+    g_used_port_num += 1;
+    portData = (PortData*)realloc(portData, g_used_port_num * sizeof(PortData));
+    g_is_using = (uint8_t*)realloc(g_is_using, g_used_port_num * sizeof(uint8_t));
+  }
+
+  setPortNameCMSIS(port_num, port_name);
+
+  // Check that the port_name was valid
+  if (portData[port_num].driver == NULL)
+      return -1;
+
+  g_is_using[port_num] = False;
+  return 0;
+}
+
+uint8_t openPortCMSIS(int port_num)
+{
+  portData[port_num].driver->Initialize(NULL);
+  portData[port_num].driver->PowerControl(ARM_POWER_FULL);
+
+  if(portData[port_num].baudrate)
+    setBaudRateCMSIS(port_num, portData[port_num].baudrate);
+
+  return 0;
+}
+
+void closePortCMSIS(int port_num)
+{
+  clearPortCMSIS(port_num);
+
+  portData[port_num].driver->Uninitialize();
+  portData[port_num].driver->PowerControl(ARM_POWER_OFF);
+}
+
+void clearPortCMSIS(int port_num)
+{
+  if (!portData[port_num].rx_busy)
+      return;
+
+  portData[port_num].driver->Control(ARM_USART_ABORT_RECEIVE, 0);
+  portData[port_num].rx_busy = False;
+}
+
+void setPortNameCMSIS(int port_num, const char *port_name)
+{
+  int index = 0;
+  portData[port_num].driver = NULL;
+
+  while (deviceLookup[index].name != NULL) {
+    if (strcmp(deviceLookup[index].name, port_name) == 0)
+    {
+      strncpy(portData[port_num].port_name, deviceLookup[index].name, NAME_SIZE);
+      portData[port_num].driver = deviceLookup[index].driver;
+      portData[port_num].rx_busy = False;
+      break;
+    }
+  }
+}
+
+char *getPortNameCMSIS(int port_num)
+{
+  return portData[port_num].port_name;
+}
+
+uint8_t setBaudRateCMSIS(int port_num, const int baudrate)
+{
+  portData[port_num].baudrate = baudrate;
+  if (portData[port_num].driver->Control(ARM_USART_MODE_ASYNCHRONOUS, baudrate) < 0)
+    return False;
+
+  portData[port_num].tx_time_per_byte = (1000.0 / (double)portData[port_num].baudrate) * 10.0;
+  return True;
+}
+
+int getBaudRateCMSIS(int port_num)
+{
+  return portData[port_num].baudrate;
+}
+
+int readPortCMSIS(int port_num, uint8_t *packet, int length)
+{
+  if (!portData[port_num].rx_busy)
+  {
+    // Start receive
+    portData[port_num].driver->Receive(packet, length);
+    portData[port_num].rx_busy = True;
+    return 0;
+  }
+
+  // Wait for transfer to finish
+  if(portData[port_num].driver->GetStatus().rx_busy)
+    return 0;
+
+  portData[port_num].rx_busy = False;
+  return portData[port_num].driver->GetRxCount();
+}
+
+int writePortCMSIS(int port_num, uint8_t *packet, int length)
+{
+  enableTransmitCMSIS();
+  portData[port_num].driver->Send(packet, length);
+
+  // Block for write
+  while(portData[port_num].driver->GetStatus().tx_busy) {};
+  disableTransmitCMSIS();
+
+  return portData[port_num].driver->GetTxCount();
+}
+
+void setPacketTimeoutCMSIS(int port_num, uint16_t packet_length)
+{
+  portData[port_num].packet_start_time = getCurrentTimeCMSIS();
+  portData[port_num].packet_timeout = (portData[port_num].tx_time_per_byte * (double)packet_length) + (LATENCY_TIMER * 2.0);
+}
+
+void setPacketTimeoutMSecCMSIS(int port_num, double msec)
+{
+  portData[port_num].packet_start_time = getCurrentTimeCMSIS();
+  portData[port_num].packet_timeout = msec;
+}
+
+uint8_t isPacketTimeoutCMSIS(int port_num)
+{
+  if (getTimeSinceStartCMSIS(port_num) > portData[port_num].packet_timeout)
+  {
+    portData[port_num].packet_timeout = 0;
+    return True;
+  }
+  return False;
+}
+
+double getTimeSinceStartCMSIS(int port_num)
+{
+  double time_since_start;
+
+  time_since_start = getCurrentTimeCMSIS() - portData[port_num].packet_start_time;
+  if (time_since_start < 0.0)
+    portData[port_num].packet_start_time = getCurrentTimeCMSIS();
+
+  return time_since_start;
+}
+
+#endif

--- a/c/src/dynamixel_sdk/port_handler_cmsis.c
+++ b/c/src/dynamixel_sdk/port_handler_cmsis.c
@@ -108,7 +108,7 @@ int portHandlerCMSIS(const char *port_name)
       return -1;
 
   g_is_using[port_num] = False;
-  return 0;
+  return port_num;
 }
 
 uint8_t openPortCMSIS(int port_num)

--- a/c/src/dynamixel_sdk/protocol1_packet_handler.c
+++ b/c/src/dynamixel_sdk/protocol1_packet_handler.c
@@ -23,6 +23,8 @@
 #elif defined(_WIN32) || defined(_WIN64)
 #define WINDLLEXPORT
 #include "protocol1_packet_handler.h"
+#elif defined(__USE_CMSIS)
+#include "protocol1_packet_handler.h"
 #endif
 
 #include <string.h>

--- a/c/src/dynamixel_sdk/protocol2_packet_handler.c
+++ b/c/src/dynamixel_sdk/protocol2_packet_handler.c
@@ -26,6 +26,8 @@
 #define WINDLLEXPORT
 #include <Windows.h>
 #include "protocol2_packet_handler.h"
+#elif defined(__USE_CMSIS)
+#include "protocol2_packet_handler.h"
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
Replaces #356

This adds a port handler that can use Cortex Microcontroller Software Interface Standard (CMSIS) style USART drivers.

User implementations must define __USE_CMSIS and provide a run-time environment file (this should be handled by their SDK).  An example RTE_Device.h file can be found [here](https://github.com/ARM-software/CMSIS/blob/master/CMSIS/Pack/Example/CMSIS_Driver/Config/RTE_Device.h).

Additionally the user must declare timing and transmit enable/disable functions for their hardware.

Example:
```c
#include "dynamixel_sdk.h"

double getCurrentTimeCMSIS()
{
    return (double)BOARD_Millis();
}

void enableTransmitCMSIS()
{
    GPIO_PortSet(UART1_DIR_GPIO, (1 << UART1_DIR_PIN));
}

void disableTransmitCMSIS()
{
    while(!(kUART_TransmissionCompleteFlag & UART_GetStatusFlags(UART1))) {}
    GPIO_PortClear(UART1_DIR_GPIO, (1 << UART1_DIR_PIN));
}

int main()
{
    // ... init ...

    int dynamixel_port = portHandler("USART1");
    packetHandler();

    openPort(dynamixel_port);
    setBaudRate(dynamixel_port, 57600);

    // ... loop ..
} 
```