### PR TITLE
3x faster getError member function of GroupSync&BulkRead Class

### DIFF
--- a/c++/src/dynamixel_sdk/group_bulk_read.cpp
+++ b/c++/src/dynamixel_sdk/group_bulk_read.cpp
@@ -232,14 +232,5 @@ bool GroupBulkRead::getError(uint8_t id, uint8_t* error)
   // TODO : check protocol version, last_result_, data_list
   // if (last_result_ == false || error_list_.find(id) == error_list_.end())
 
-  error[0] = error_list_[id][0];
-
-  if (error[0] != 0)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return error[0] = error_list_[id][0];
 }

--- a/c++/src/dynamixel_sdk/group_sync_read.cpp
+++ b/c++/src/dynamixel_sdk/group_sync_read.cpp
@@ -201,14 +201,5 @@ bool GroupSyncRead::getError(uint8_t id, uint8_t* error)
   // TODO : check protocol version, last_result_, data_list
   // if (ph_->getProtocolVersion() == 1.0 || last_result_ == false || error_list_.find(id) == error_list_.end())
 
-  error[0] = error_list_[id][0];
-
-  if (error[0] != 0)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return error[0] = error_list_[id][0];
 }


### PR DESCRIPTION
removed condition state so that we can reduce the stall caused by the branch statement.

The below code is the test code.
```
#include <iostream>
#include <time.h>

using namespace std;

uint8_t error_list[1000];

bool getErrorAnchor(int id, uint8_t* error)
{
    error[id] = error_list[id];

    if(error[id] != 0) return true;
    else return false;
}

bool getErrorProposed(int id, uint8_t* error)
{
    return error[id] = error_list[id];
}


int main()
{
    for(int i = 0; i < 1000; i++)
    {
        error_list[i] = rand()%2;
    }

    uint8_t error[1000];

    clock_t begin, end;
    begin = clock();

    for (int n = 0; n < 100000; n++)
        for(int i = 0; i < 1000; i++)
        {
            getErrorAnchor(i, error);
        }
    end = clock();
    cout<<"Execution time _testAnchor : "<<((double)(end-begin)/CLOCKS_PER_SEC)<<endl;

    begin = clock();

    for (int n = 0; n < 100000; n++)
        for(int i = 0; i < 1000; i++)
        {
            getErrorProposed(i, error);
        }
    end = clock();
    cout<<"Execution time _testProposed : "<<((double)(end-begin)/CLOCKS_PER_SEC)<<endl;
    return 0;
}
```

I got the results shown here.

```
Execution time _testAnchor : 0.858
Execution time _testProposed : 0.263
```
