### PR TITLE
Update .gitignore to exclude python build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@
 
 # Mac
 .DS_Store
+
+# Visual Studio Code
+.vscode/
+
+# Python Install Build Files
+python/build/
+python/dist/
+python/src/dynamixel_sdk.egg-info/


### PR DESCRIPTION
The build files from running setup.py is not getting ignored and may mess up git submodule tracking. This pull request fixes the above issue. 