### PR TITLE
Fix "txpacket() randomly gets stuck on Linux"

### DIFF
--- a/python/src/dynamixel_sdk/port_handler.py
+++ b/python/src/dynamixel_sdk/port_handler.py
@@ -48,7 +48,7 @@ class PortHandler(object):
         self.is_open = False
 
     def clearPort(self):
-        self.ser.flush()
+        self.ser.reset_input_buffer()
 
     def setPortName(self, port_name):
         self.port_name = port_name


### PR DESCRIPTION
This fixes the issue "Python SDK randomly gets stuck on txpacket()".

* It turned out that Python SDK calls `termios.tcdrain()` to clear remaining
   data in the serial port.
* Since `tcdrain()` is a blocking operation, it can paralyze the Python
  interpreter for a few seconds.

On the other hand, C/C++ SDK uses `tcflush()` for the same purpose, so
simply dicards the data not transmitted yet. Fix Python SDK to do the same.

Related: See https://github.com/pyserial/pyserial/issues/625 for related discussion in pyserial/pyserial.