### PR TITLE
Fix write only instructions (Protocol 2.0)

### DIFF
--- a/python/src/dynamixel_sdk/protocol2_packet_handler.py
+++ b/python/src/dynamixel_sdk/protocol2_packet_handler.py
@@ -801,7 +801,7 @@ class Protocol2PacketHandler(object):
 
         txpacket[PKT_PARAMETER0 + 4: PKT_PARAMETER0 + 4 + param_length] = param[0: param_length]
 
-        _, result, _ = self.txRxPacket(port, txpacket)
+        result = self.txPacket(port, txpacket)
 
         return result
 
@@ -841,6 +841,6 @@ class Protocol2PacketHandler(object):
 
         txpacket[PKT_PARAMETER0: PKT_PARAMETER0 + param_length] = param[0: param_length]
 
-        _, result, _ = self.txRxPacket(port, txpacket)
+        result = self.txPacket(port, txpacket)
 
         return result

--- a/python/src/dynamixel_sdk/protocol2_packet_handler.py
+++ b/python/src/dynamixel_sdk/protocol2_packet_handler.py
@@ -801,9 +801,7 @@ class Protocol2PacketHandler(object):
 
         txpacket[PKT_PARAMETER0 + 4: PKT_PARAMETER0 + 4 + param_length] = param[0: param_length]
 
-        result = self.txPacket(port, txpacket)
-
-        return result
+        return self.txPacket(port, txpacket)
 
     def bulkReadTx(self, port, param, param_length, fast_option):
         txpacket = [0] * (param_length + 10)
@@ -841,6 +839,4 @@ class Protocol2PacketHandler(object):
 
         txpacket[PKT_PARAMETER0: PKT_PARAMETER0 + param_length] = param[0: param_length]
 
-        result = self.txPacket(port, txpacket)
-
-        return result
+        return self.txPacket(port, txpacket)


### PR DESCRIPTION
Unless I'm missing something, `syncWriteTxOnly` `bulkWriteTxOnly` in the `Protocol2PacketHandler` should not expect a status packet. However currently they call `txRxPacket` instead of simply `txPacket`. This PR addresses that.

Note: In practice, these functions won't fail for broadcast instructions because of [these lines](https://github.com/ROBOTIS-GIT/DynamixelSDK/blob/6eb6f3737d5bddd5bd1ea2e6b96647221a4d30a4/python/src/dynamixel_sdk/protocol2_packet_handler.py#L337-L341) in `txRxPacket`:
```python
# (ID == Broadcast ID) == no need to wait for status packet or not available.
# (Instruction == action) == no need to wait for status packet
if txpacket[PKT_ID] == BROADCAST_ID or txpacket[PKT_INSTRUCTION] == INST_ACTION:
    port.is_using = False
    return rxpacket, result, error
```
Still, execution shouldn't even get to that point by intent of what `syncWriteTxOnly` and `bulkWriteTxOnly` are meant to accomplish