### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/dynamixel_sdk_examples/CMakeLists.txt
+++ b/dynamixel_sdk_examples/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories(include)
 
 # Build
 add_executable(read_write_node src/read_write_node.cpp)
-ament_target_dependencies(read_write_node
+target_link_libraries(read_write_node PUBLIC
   dynamixel_sdk_custom_interfaces
   dynamixel_sdk
   rclcpp


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
