### PR TITLE
Bugfix: Check that read data has correct length

### DIFF
--- a/python/src/dynamixel_sdk/protocol2_packet_handler.py
+++ b/python/src/dynamixel_sdk/protocol2_packet_handler.py
@@ -549,6 +549,10 @@ class Protocol2PacketHandler(object):
 
             data.extend(rxpacket[PKT_PARAMETER0 + 1: PKT_PARAMETER0 + 1 + length])
 
+            if len(data) != length:
+                result = COMM_RX_CORRUPT
+                return data, result, error
+
         return data, result, error
 
     def fastSyncReadRx(self, port, dxl_id, length):
@@ -618,6 +622,10 @@ class Protocol2PacketHandler(object):
             error = rxpacket[PKT_ERROR]
 
             data.extend(rxpacket[PKT_PARAMETER0 + 1: PKT_PARAMETER0 + 1 + length])
+
+            if len(data) != length:
+                result = COMM_RX_CORRUPT
+                return data, result, error
 
         return data, result, error
 


### PR DESCRIPTION
Dynamixels occasionally return a one byte (0x00) status when performing a sync read, this causes class GroupSyncRead.getData to crash with an index out of bounds exception.