### PR TITLE
Set baud rate using cfsetispeed

### DIFF
--- a/c++/src/dynamixel_sdk/port_handler_linux.cpp
+++ b/c++/src/dynamixel_sdk/port_handler_linux.cpp
@@ -211,12 +211,16 @@ bool PortHandlerLinux::setupPort(int cflag_baud)
 
   bzero(&newtio, sizeof(newtio)); // clear struct for new port settings
 
-  newtio.c_cflag = cflag_baud | CS8 | CLOCAL | CREAD;
+  newtio.c_cflag = CS8 | CLOCAL | CREAD;
   newtio.c_iflag = IGNPAR;
   newtio.c_oflag      = 0;
   newtio.c_lflag      = 0;
   newtio.c_cc[VTIME]  = 0;
   newtio.c_cc[VMIN]   = 0;
+
+  // Set baud rate using portable cfset*speed functions
+  cfsetispeed(&newtio, cflag_baud);
+  cfsetospeed(&newtio, cflag_baud);
 
   // clean the buffer and activate the settings for the port
   tcflush(socket_fd_, TCIFLUSH);


### PR DESCRIPTION
On Ubuntu 25.10 running on framework desktop (Ryzen 395+) with CH341 / CH340, the way the original code sets the baud rate does not work. 

Using cfsetospeed and cfsetispeed instead works as it should. 