### PR TITLE
Dynamixel SDK cpp RAII updates

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "DynamixelSDK c++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 5.0.0
+PROJECT_NUMBER         = 4.1.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "DynamixelSDK c++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 4.0.4
+PROJECT_NUMBER         = 5.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -4,6 +4,8 @@
 ------------------
 * Updated the standalone C++ SDK and ROS 2 C++ wrappers to use safer dynamic storage for group and packet buffers
 * Bumped the C++ shared library ABI to SOVERSION 3 due to public C++ class layout changes
+* Added VERSION 5.0.0 and SOVERSION 3 to the ROS 2 shared library target for consistent ABI versioning
+* Changed the C++ uninstall step to remove SDK-owned install paths by name instead of relying on the install manifest
 * Unified package versioning to 5.0.0 across C, C++, Python, and ROS 2 packaging metadata
 * Contributors: Hyungyu Kim
 

--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,5 +1,12 @@
 # Dynamixel SDK Release Notes
 
+5.0.0 (2026-04-09)
+------------------
+* Updated the standalone C++ SDK and ROS 2 C++ wrappers to use safer dynamic storage for group and packet buffers
+* Bumped the C++ shared library ABI to SOVERSION 3 due to public C++ class layout changes
+* Unified package versioning to 5.0.0 across C, C++, Python, and ROS 2 packaging metadata
+* Contributors: Hyungyu Kim
+
 4.0.4 (2026-03-27)
 ------------------
 * Added CMakeLists.txt for unified build system in c, c++

--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,12 +1,12 @@
 # Dynamixel SDK Release Notes
 
-5.0.0 (2026-04-09)
+4.1.0 (2026-04-14)
 ------------------
 * Updated the standalone C++ SDK and ROS 2 C++ wrappers to use safer dynamic storage for group and packet buffers
 * Bumped the C++ shared library ABI to SOVERSION 3 due to public C++ class layout changes
-* Added VERSION 5.0.0 and SOVERSION 3 to the ROS 2 shared library target for consistent ABI versioning
+* Added VERSION 4.1.0 and SOVERSION 3 to the ROS 2 shared library target for consistent ABI versioning
 * Changed the C++ uninstall step to remove SDK-owned install paths by name instead of relying on the install manifest
-* Unified package versioning to 5.0.0 across C, C++, Python, and ROS 2 packaging metadata
+* Unified package versioning to 4.1.0 across C, C++, Python, and ROS 2 packaging metadata
 * Contributors: Hyungyu Kim
 
 4.0.4 (2026-03-27)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Standalone C++ SDK: configure/build from the c++/ directory (paths below are relative to c++/).
-project(dynamixel_sdk VERSION 4.0.4 LANGUAGES CXX)
+project(dynamixel_sdk VERSION 5.0.0 LANGUAGES CXX)
 
 set(_dxl_pkg "dynamixel_sdk")
 
@@ -73,7 +73,7 @@ target_include_directories(dynamixel_sdk PRIVATE
 
 set_target_properties(dynamixel_sdk PROPERTIES
   VERSION ${PROJECT_VERSION}
-  SOVERSION 2
+  SOVERSION 3
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED ON
   OUTPUT_NAME "dxl_cpp"
@@ -159,12 +159,23 @@ if(DYNAMIXEL_SDK_RUN_LDCONFIG AND UNIX AND NOT APPLE)
 endif()
 
 # --------------------------------------------------------
-# 4. Uninstall / Reinstall Targets
+# 4. Uninstall / Reinstall Targets (name-based; no install_manifest.txt required)
 # --------------------------------------------------------
+if(UNIX AND NOT APPLE)
+  set(DXL_UNINSTALL_EASY_SDK 1)
+else()
+  set(DXL_UNINSTALL_EASY_SDK 0)
+endif()
+if(WIN32)
+  set(DXL_UNINSTALL_WIN32 1)
+else()
+  set(DXL_UNINSTALL_WIN32 0)
+endif()
+
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-  IMMEDIATE @ONLY
+  @ONLY
 )
 
 if(NOT TARGET uninstall)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -159,7 +159,7 @@ if(DYNAMIXEL_SDK_RUN_LDCONFIG AND UNIX AND NOT APPLE)
 endif()
 
 # --------------------------------------------------------
-# 4. Uninstall / Reinstall Targets (name-based; no install_manifest.txt required)
+# 4. Uninstall / Reinstall Targets
 # --------------------------------------------------------
 if(UNIX AND NOT APPLE)
   set(DXL_UNINSTALL_EASY_SDK 1)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Standalone C++ SDK: configure/build from the c++/ directory (paths below are relative to c++/).
-project(dynamixel_sdk VERSION 5.0.0 LANGUAGES CXX)
+project(dynamixel_sdk VERSION 4.1.0 LANGUAGES CXX)
 
 set(_dxl_pkg "dynamixel_sdk")
 

--- a/c++/build/linux32/Makefile
+++ b/c++/build/linux32/Makefile
@@ -10,7 +10,7 @@ DIR_OBJS    = ./.objects
 
 INSTALL_ROOT = /usr/local
 
-MAJ_VERSION = 2
+MAJ_VERSION = 3
 MIN_VERSION = 0
 REV_VERSION = 0
 

--- a/c++/build/linux64/Makefile
+++ b/c++/build/linux64/Makefile
@@ -10,7 +10,7 @@ DIR_OBJS    = ./.objects
 
 INSTALL_ROOT = /usr/local
 
-MAJ_VERSION = 2
+MAJ_VERSION = 3
 MIN_VERSION = 0
 REV_VERSION = 0
 

--- a/c++/build/linux_sbc/Makefile
+++ b/c++/build/linux_sbc/Makefile
@@ -10,7 +10,7 @@ DIR_OBJS    = ./.objects
 
 INSTALL_ROOT = /usr/local
 
-MAJ_VERSION = 2
+MAJ_VERSION = 3
 MIN_VERSION = 0
 REV_VERSION = 0
 

--- a/c++/build/mac/Makefile
+++ b/c++/build/mac/Makefile
@@ -10,7 +10,7 @@ DIR_OBJS    = ./.objects
 
 INSTALL_ROOT = /usr/local
 
-MAJ_VERSION = 2
+MAJ_VERSION = 3
 MIN_VERSION = 0
 REV_VERSION = 0
 

--- a/c++/cmake/cmake_uninstall.cmake.in
+++ b/c++/cmake/cmake_uninstall.cmake.in
@@ -1,53 +1,56 @@
-# Uninstall files listed in install_manifest.txt (created by cmake --install).
-# Configured from cmake_uninstall.cmake.in via configure_file(... IMMEDIATE @ONLY).
+# Name-based uninstall for Dynamixel SDK (C++), under CMAKE_INSTALL_PREFIX.
+# Removes the same layout as install(): headers, libdxl_cpp.*, CMake package config,
+# share/dynamixel_sdk (incl. control_table), and dynamixel_easy_sdk headers on Linux.
 
-if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
-  message(FATAL_ERROR
-    "Cannot find @CMAKE_BINARY_DIR@/install_manifest.txt\n"
-    "Run: cmake --install <build-dir> (or make install) at least once so the manifest exists."
-  )
+set(_dxl_prefix "@CMAKE_INSTALL_PREFIX@")
+string(REGEX REPLACE "/+$" "" _dxl_prefix "${_dxl_prefix}")
+
+set(_dxl_inc "@CMAKE_INSTALL_INCLUDEDIR@")
+set(_dxl_lib "@CMAKE_INSTALL_LIBDIR@")
+set(_dxl_share "@CMAKE_INSTALL_DATAROOTDIR@")
+set(_dxl_bin "@CMAKE_INSTALL_BINDIR@")
+
+message(STATUS "Dynamixel SDK (C++) uninstall from prefix: ${_dxl_prefix}")
+
+macro(_dxl_remove_tree _path)
+  if(EXISTS "${_path}")
+    file(REMOVE_RECURSE "${_path}")
+    message(STATUS "Removed ${_path}")
+  endif()
+endmacro()
+
+# Headers: dynamixel_sdk (all platforms)
+_dxl_remove_tree("${_dxl_prefix}/${_dxl_inc}/dynamixel_sdk")
+
+# dynamixel_easy_sdk: same condition as install() (Linux, not Apple)
+if(@DXL_UNINSTALL_EASY_SDK@)
+  _dxl_remove_tree("${_dxl_prefix}/${_dxl_inc}/dynamixel_easy_sdk")
 endif()
 
-file(STRINGS "@CMAKE_BINARY_DIR@/install_manifest.txt" _dxl_installed_files)
-
-foreach(_dxl_file IN LISTS _dxl_installed_files)
-  string(STRIP "${_dxl_file}" _dxl_file)
-  if(_dxl_file STREQUAL "")
-    continue()
-  endif()
-  message(STATUS "Uninstalling: ${_dxl_file}")
-  # EXISTS is false for broken symlinks, so also check IS_SYMLINK.
-  if(EXISTS "${_dxl_file}" OR IS_SYMLINK "${_dxl_file}")
-    file(REMOVE "${_dxl_file}")
-  endif()
-endforeach()
-
-# Remove installed directories (manifest only removes files).
-# Derive prefix from install_manifest.txt paths so --prefix overrides work.
-set(_dxl_prefix "")
-foreach(_dxl_file IN LISTS _dxl_installed_files)
-  string(STRIP "${_dxl_file}" _dxl_file_stripped)
-  if(_dxl_file_stripped STREQUAL "")
-    continue()
-  endif()
-
-  # Example:
-  #   ${prefix}/include/dynamixel_sdk/dynamixel_sdk.h
-  if(_dxl_file_stripped MATCHES "^(.*)/@CMAKE_INSTALL_INCLUDEDIR@/dynamixel_sdk/.*$")
-    set(_dxl_prefix "${CMAKE_MATCH_1}")
-    break()
-  endif()
-endforeach()
-
-if(NOT _dxl_prefix STREQUAL "")
-  file(REMOVE_RECURSE "${_dxl_prefix}/@CMAKE_INSTALL_INCLUDEDIR@/dynamixel_sdk")
-  if(NOT APPLE)
-    file(REMOVE_RECURSE "${_dxl_prefix}/@CMAKE_INSTALL_INCLUDEDIR@/dynamixel_easy_sdk")
-  endif()
-
-  if(NOT APPLE)
-    file(REMOVE_RECURSE "${_dxl_prefix}/@CMAKE_INSTALL_DATAROOTDIR@/dynamixel_sdk/control_table")
-  endif()
-
-  file(REMOVE_RECURSE "${_dxl_prefix}/@CMAKE_INSTALL_LIBDIR@/cmake/dynamixel_sdk")
+# Shared library / import lib
+if(@DXL_UNINSTALL_WIN32@)
+  file(GLOB _dxl_dlls LIST_DIRECTORIES false "${_dxl_prefix}/${_dxl_bin}/dxl_cpp.dll")
+  foreach(_f IN LISTS _dxl_dlls)
+    message(STATUS "Uninstalling: ${_f}")
+    file(REMOVE "${_f}")
+  endforeach()
+  foreach(_name "dxl_cpp.lib" "dxl_cpp.exp")
+    set(_f "${_dxl_prefix}/${_dxl_lib}/${_name}")
+    if(EXISTS "${_f}")
+      message(STATUS "Uninstalling: ${_f}")
+      file(REMOVE "${_f}")
+    endif()
+  endforeach()
+else()
+  file(GLOB _dxl_libs LIST_DIRECTORIES false "${_dxl_prefix}/${_dxl_lib}/libdxl_cpp.*")
+  foreach(_f IN LISTS _dxl_libs)
+    message(STATUS "Uninstalling: ${_f}")
+    file(REMOVE "${_f}")
+  endforeach()
 endif()
+
+# CMake package files
+_dxl_remove_tree("${_dxl_prefix}/${_dxl_lib}/cmake/dynamixel_sdk")
+
+# share (e.g. control_table)
+_dxl_remove_tree("${_dxl_prefix}/${_dxl_share}/dynamixel_sdk")

--- a/c++/include/dynamixel_sdk/group_bulk_read.h
+++ b/c++/include/dynamixel_sdk/group_bulk_read.h
@@ -38,7 +38,7 @@ class WINDECLSPEC GroupBulkRead : public GroupHandler
 protected:
     std::map<uint8_t, uint16_t> address_list_;  // <id, start_address>
     std::map<uint8_t, uint16_t> length_list_;   // <id, data_length>
-    std::map<uint8_t, uint8_t *> error_list_;   // <id, error>
+    std::map<uint8_t, std::vector<uint8_t>> error_list_;   // <id, error>
 
     bool last_result_;
 
@@ -135,7 +135,7 @@ public:
   /// @error error of Dynamixel
   /// @return true
   /// @return   when Dynamixel returned specific error byte
-  /// @return or false 
+  /// @return or false
   ////////////////////////////////////////////////////////////////////////////////
   bool        getError    (uint8_t id, uint8_t* error);
 };

--- a/c++/include/dynamixel_sdk/group_fast_bulk_read.h
+++ b/c++/include/dynamixel_sdk/group_fast_bulk_read.h
@@ -40,6 +40,7 @@ public:
 
 private:
     void makeParam();
+    std::vector<uint8_t> rxpacket_;
 };
 
 }

--- a/c++/include/dynamixel_sdk/group_fast_sync_read.h
+++ b/c++/include/dynamixel_sdk/group_fast_sync_read.h
@@ -37,6 +37,9 @@ public:
     int txPacket();
     int rxPacket();
     int txRxPacket();
+
+private:
+    std::vector<uint8_t> rxpacket_;
 };
 
 }

--- a/c++/include/dynamixel_sdk/group_handler.h
+++ b/c++/include/dynamixel_sdk/group_handler.h
@@ -44,11 +44,11 @@ protected:
     PacketHandler *ph_;
 
     std::vector<uint8_t> id_list_;
-    std::map<uint8_t, uint8_t *> data_list_;     // <id, data>
+    std::map<uint8_t, std::vector<uint8_t>> data_list_;     // <id, data>
 
     bool is_param_changed_;
 
-    uint8_t *param_;
+    std::vector<uint8_t> param_;
 };
 
 }

--- a/c++/include/dynamixel_sdk/group_sync_read.h
+++ b/c++/include/dynamixel_sdk/group_sync_read.h
@@ -36,7 +36,7 @@ namespace dynamixel
 class WINDECLSPEC GroupSyncRead : public GroupHandler
 {
 protected:
-    std::map<uint8_t, uint8_t *> error_list_; // <id, error>
+    std::map<uint8_t, std::vector<uint8_t>> error_list_; // <id, error>
 
     bool last_result_;
 
@@ -140,7 +140,7 @@ public:
   /// @error error of Dynamixel
   /// @return true
   /// @return   when Dynamixel returned specific error byte
-  /// @return or false 
+  /// @return or false
   ////////////////////////////////////////////////////////////////////////////////
   bool        getError    (uint8_t id, uint8_t* error);
 };

--- a/c++/include/dynamixel_sdk/packet_handler.h
+++ b/c++/include/dynamixel_sdk/packet_handler.h
@@ -39,12 +39,12 @@
 #define MAX_ID              0xFC    // 252
 
 /* Macro for Control Table Value */
-#define DXL_MAKEWORD(a, b)  ((uint16_t)(((uint8_t)(((uint64_t)(a)) & 0xff)) | ((uint16_t)((uint8_t)(((uint64_t)(b)) & 0xff))) << 8))
-#define DXL_MAKEDWORD(a, b) ((uint32_t)(((uint16_t)(((uint64_t)(a)) & 0xffff)) | ((uint32_t)((uint16_t)(((uint64_t)(b)) & 0xffff))) << 16))
-#define DXL_LOWORD(l)       ((uint16_t)(((uint64_t)(l)) & 0xffff))
-#define DXL_HIWORD(l)       ((uint16_t)((((uint64_t)(l)) >> 16) & 0xffff))
-#define DXL_LOBYTE(w)       ((uint8_t)(((uint64_t)(w)) & 0xff))
-#define DXL_HIBYTE(w)       ((uint8_t)((((uint64_t)(w)) >> 8) & 0xff))
+#define DXL_MAKEWORD(a, b)  (static_cast<uint16_t>((static_cast<uint8_t>(static_cast<uint64_t>(a) & 0xff)) | (static_cast<uint16_t>(static_cast<uint8_t>(static_cast<uint64_t>(b) & 0xff))) << 8))
+#define DXL_MAKEDWORD(a, b) (static_cast<uint32_t>((static_cast<uint16_t>(static_cast<uint64_t>(a) & 0xffff)) | (static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint64_t>(b) & 0xffff))) << 16))
+#define DXL_LOWORD(l)       (static_cast<uint16_t>(static_cast<uint64_t>(l) & 0xffff))
+#define DXL_HIWORD(l)       (static_cast<uint16_t>((static_cast<uint64_t>(l) >> 16) & 0xffff))
+#define DXL_LOBYTE(w)       (static_cast<uint8_t>(static_cast<uint64_t>(w) & 0xff))
+#define DXL_HIBYTE(w)       (static_cast<uint8_t>((static_cast<uint64_t>(w) >> 8) & 0xff))
 
 /* Instruction for DXL Protocol */
 #define INST_PING               1

--- a/c++/library.properties
+++ b/c++/library.properties
@@ -1,5 +1,5 @@
 name=DynamixelSDK
-version=4.0.4
+version=5.0.0
 author=ROBOTIS
 maintainer=ROBOTIS
 sentence=DynamixelSDK for Arduino

--- a/c++/library.properties
+++ b/c++/library.properties
@@ -1,5 +1,5 @@
 name=DynamixelSDK
-version=5.0.0
+version=4.1.0
 author=ROBOTIS
 maintainer=ROBOTIS
 sentence=DynamixelSDK for Arduino

--- a/c++/src/dynamixel_sdk/group_bulk_write.cpp
+++ b/c++/src/dynamixel_sdk/group_bulk_write.cpp
@@ -40,33 +40,29 @@ GroupBulkWrite::GroupBulkWrite(PortHandler *port, PacketHandler *ph)
 
 void GroupBulkWrite::makeParam()
 {
-  if (ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
+  if (ph_->getProtocolVersion() == 1.0 || id_list_.empty())
     return;
-
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
 
   param_length_ = 0;
   for (unsigned int i = 0; i < id_list_.size(); i++)
     param_length_ += 1 + 2 + 2 + length_list_[id_list_[i]];
 
-  param_ = new uint8_t[param_length_];
+  param_.clear();
+  param_.reserve(param_length_);
 
-  int idx = 0;
   for (unsigned int i = 0; i < id_list_.size(); i++)
   {
     uint8_t id = id_list_[i];
-    if (data_list_[id] == 0)
+    if (data_list_.find(id) == data_list_.end())
       return;
 
-    param_[idx++] = id;
-    param_[idx++] = DXL_LOBYTE(address_list_[id]);
-    param_[idx++] = DXL_HIBYTE(address_list_[id]);
-    param_[idx++] = DXL_LOBYTE(length_list_[id]);
-    param_[idx++] = DXL_HIBYTE(length_list_[id]);
+    param_.push_back(id);
+    param_.push_back(DXL_LOBYTE(address_list_[id]));
+    param_.push_back(DXL_HIBYTE(address_list_[id]));
+    param_.push_back(DXL_LOBYTE(length_list_[id]));
+    param_.push_back(DXL_HIBYTE(length_list_[id]));
     for (int c = 0; c < length_list_[id]; c++)
-      param_[idx++] = (data_list_[id])[c];
+      param_.push_back((data_list_[id])[c]);
   }
 }
 
@@ -81,9 +77,7 @@ bool GroupBulkWrite::addParam(uint8_t id, uint16_t start_address, uint16_t data_
   id_list_.push_back(id);
   address_list_[id]   = start_address;
   length_list_[id]    = data_length;
-  data_list_[id]      = new uint8_t[data_length];
-  for (int c = 0; c < data_length; c++)
-    data_list_[id][c] = data[c];
+  data_list_[id].assign(data, data + data_length);
 
   is_param_changed_   = true;
   return true;
@@ -100,7 +94,6 @@ void GroupBulkWrite::removeParam(uint8_t id)
   id_list_.erase(it);
   address_list_.erase(id);
   length_list_.erase(id);
-  delete[] data_list_[id];
   data_list_.erase(id);
 
   is_param_changed_   = true;
@@ -116,37 +109,29 @@ bool GroupBulkWrite::changeParam(uint8_t id, uint16_t start_address, uint16_t da
 
   address_list_[id]   = start_address;
   length_list_[id]    = data_length;
-  delete[] data_list_[id];
-  data_list_[id]      = new uint8_t[data_length];
-  for (int c = 0; c < data_length; c++)
-    data_list_[id][c] = data[c];
+  data_list_[id].assign(data, data + data_length);
 
   is_param_changed_   = true;
   return true;
 }
 void GroupBulkWrite::clearParam()
 {
-  if (ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
+  if (ph_->getProtocolVersion() == 1.0 || id_list_.empty())
     return;
-
-  for (unsigned int i = 0; i < id_list_.size(); i++)
-    delete[] data_list_[id_list_[i]];
 
   id_list_.clear();
   address_list_.clear();
   length_list_.clear();
   data_list_.clear();
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
+  param_.clear();
 }
 int GroupBulkWrite::txPacket()
 {
-  if (ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
+  if (ph_->getProtocolVersion() == 1.0 || id_list_.empty())
     return COMM_NOT_AVAILABLE;
 
-  if (is_param_changed_ == true || param_ == 0)
+  if (is_param_changed_ == true || param_.empty())
     makeParam();
 
-  return ph_->bulkWriteTxOnly(port_, param_, param_length_);
+  return ph_->bulkWriteTxOnly(port_, param_.data(), param_length_);
 }

--- a/c++/src/dynamixel_sdk/group_bulk_write.cpp
+++ b/c++/src/dynamixel_sdk/group_bulk_write.cpp
@@ -133,5 +133,10 @@ int GroupBulkWrite::txPacket()
   if (is_param_changed_ == true || param_.empty())
     makeParam();
 
-  return ph_->bulkWriteTxOnly(port_, param_.data(), param_length_);
+  if (param_.size() != static_cast<size_t>(param_length_) ||
+      param_.size() > 0xFFFFu)
+    return COMM_TX_ERROR;
+
+  return ph_->bulkWriteTxOnly(
+      port_, param_.data(), static_cast<uint16_t>(param_.size()));
 }

--- a/c++/src/dynamixel_sdk/group_fast_bulk_read.cpp
+++ b/c++/src/dynamixel_sdk/group_fast_bulk_read.cpp
@@ -46,20 +46,16 @@ void GroupFastBulkRead::makeParam()
     if ((1.0 == ph_->getProtocolVersion()) || (id_list_.empty()))
         return;
 
-    if (0 != param_)
-        delete[] param_;
-    param_ = 0;
+    param_.clear();
+    param_.reserve(id_list_.size() * 5);
 
-    param_ = new uint8_t[id_list_.size() * 5];  // ID(1) + ADDR(2) + LENGTH(2)
-
-    int idx = 0;
     for (unsigned int i = 0; i < id_list_.size(); i++) {
         uint8_t id = id_list_[i];
-        param_[idx++] = id;                               // ID
-        param_[idx++] = DXL_LOBYTE(address_list_[id]);    // ADDR_L
-        param_[idx++] = DXL_HIBYTE(address_list_[id]);    // ADDR_H
-        param_[idx++] = DXL_LOBYTE(length_list_[id]);     // LEN_L
-        param_[idx++] = DXL_HIBYTE(length_list_[id]);     // LEN_H
+        param_.push_back(id);                               // ID
+        param_.push_back(DXL_LOBYTE(address_list_[id]));    // ADDR_L
+        param_.push_back(DXL_HIBYTE(address_list_[id]));    // ADDR_H
+        param_.push_back(DXL_LOBYTE(length_list_[id]));     // LEN_L
+        param_.push_back(DXL_HIBYTE(length_list_[id]));     // LEN_H
     }
 }
 
@@ -68,10 +64,10 @@ int GroupFastBulkRead::txPacket()
     if ((1.0 == ph_->getProtocolVersion()) || (id_list_.empty()))
         return COMM_NOT_AVAILABLE;
 
-    if ((true == is_param_changed_) || (0 == param_))
+    if ((true == is_param_changed_) || (param_.empty()))
         makeParam();
 
-    return ph_->fastBulkReadTx(port_, param_, id_list_.size() * 5);
+    return ph_->fastBulkReadTx(port_, param_.data(), id_list_.size() * 5);
 }
 
 int GroupFastBulkRead::rxPacket()
@@ -83,9 +79,9 @@ int GroupFastBulkRead::rxPacket()
 
     int count = id_list_.size();
     int result = COMM_RX_FAIL;
-    uint8_t *rxpacket = (uint8_t *)malloc(RXPACKET_MAX_LEN);
-    if (NULL == rxpacket)
-        return result;
+    if (rxpacket_.size() < static_cast<size_t>(RXPACKET_MAX_LEN))
+        rxpacket_.resize(static_cast<size_t>(RXPACKET_MAX_LEN));
+    uint8_t *rxpacket = rxpacket_.data();
 
     do {
         result = ph_->rxPacket(port_, rxpacket, true);
@@ -96,7 +92,7 @@ int GroupFastBulkRead::rxPacket()
         for (int i = 0; i < count; ++i) {
             uint8_t id = id_list_[i];
             uint16_t length = length_list_[id];
-            *error_list_[id] = (uint8_t)rxpacket[index];
+            error_list_[id][0] = static_cast<uint8_t>(rxpacket[index]);
             for (uint16_t s = 0; s < length; s++) {
                 data_list_[id][s] = rxpacket[index + 2 + s];
             }
@@ -105,7 +101,6 @@ int GroupFastBulkRead::rxPacket()
         last_result_ = true;
     }
 
-    free(rxpacket);
     return result;
 }
 

--- a/c++/src/dynamixel_sdk/group_fast_sync_read.cpp
+++ b/c++/src/dynamixel_sdk/group_fast_sync_read.cpp
@@ -46,10 +46,10 @@ int GroupFastSyncRead::txPacket()
     if ((1.0 == ph_->getProtocolVersion()) || (id_list_.empty()))
         return COMM_NOT_AVAILABLE;
 
-    if ((true == is_param_changed_) || (0 == param_))
+    if ((true == is_param_changed_) || (param_.empty()))
         makeParam();
 
-    return ph_->fastSyncReadTx(port_, start_address_, data_length_, param_, (uint16_t)id_list_.size() * 1);
+    return ph_->fastSyncReadTx(port_, start_address_, data_length_, param_.data(), static_cast<uint16_t>(id_list_.size() * 1));
 }
 
 int GroupFastSyncRead::rxPacket()
@@ -61,9 +61,9 @@ int GroupFastSyncRead::rxPacket()
 
     int count = id_list_.size();
     int result = COMM_RX_FAIL;
-    uint8_t *rxpacket = (uint8_t *)malloc(RXPACKET_MAX_LEN);
-    if (NULL == rxpacket)
-        return result;
+    if (rxpacket_.size() < static_cast<size_t>(RXPACKET_MAX_LEN))
+        rxpacket_.resize(static_cast<size_t>(RXPACKET_MAX_LEN));
+    uint8_t *rxpacket = rxpacket_.data();
 
     do {
         result = ph_->rxPacket(port_, rxpacket, true);
@@ -73,7 +73,7 @@ int GroupFastSyncRead::rxPacket()
         int index = PKT_PARAMETER0;
         for (int i = 0; i < count; ++i) {
             uint8_t id = id_list_[i];
-            *error_list_[id] = (uint8_t)rxpacket[index];
+            error_list_[id][0] = static_cast<uint8_t>(rxpacket[index]);
             for (uint16_t s = 0; s < data_length_; s++) {
                 data_list_[id][s] = rxpacket[index + 2 + s];
             }
@@ -82,7 +82,6 @@ int GroupFastSyncRead::rxPacket()
         last_result_ = true;
     }
 
-    free(rxpacket);
     return result;
 }
 

--- a/c++/src/dynamixel_sdk/group_handler.cpp
+++ b/c++/src/dynamixel_sdk/group_handler.cpp
@@ -32,8 +32,7 @@ using namespace dynamixel;
 GroupHandler::GroupHandler(PortHandler *port, PacketHandler *ph)
  : port_(port),
    ph_(ph),
-   is_param_changed_(false),
-   param_(0)
+   is_param_changed_(false)
 {
-
+  param_.clear();
 }

--- a/c++/src/dynamixel_sdk/group_sync_write.cpp
+++ b/c++/src/dynamixel_sdk/group_sync_write.cpp
@@ -41,24 +41,20 @@ GroupSyncWrite::GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t st
 
 void GroupSyncWrite::makeParam()
 {
-  if (id_list_.size() == 0) return;
+  if (id_list_.empty()) return;
 
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
+  param_.clear();
+  param_.reserve(id_list_.size() * (1 + data_length_)); // ID(1) + DATA(data_length)
 
-  param_ = new uint8_t[id_list_.size() * (1 + data_length_)]; // ID(1) + DATA(data_length)
-
-  int idx = 0;
   for (unsigned int i = 0; i < id_list_.size(); i++)
   {
     uint8_t id = id_list_[i];
-    if (data_list_[id] == 0)
+    if (data_list_.find(id) == data_list_.end())
       return;
 
-    param_[idx++] = id;
+    param_.push_back(id);
     for (int c = 0; c < data_length_; c++)
-      param_[idx++] = (data_list_[id])[c];
+      param_.push_back((data_list_[id])[c]);
   }
 }
 
@@ -68,9 +64,7 @@ bool GroupSyncWrite::addParam(uint8_t id, uint8_t *data)
     return false;
 
   id_list_.push_back(id);
-  data_list_[id]    = new uint8_t[data_length_];
-  for (int c = 0; c < data_length_; c++)
-    data_list_[id][c] = data[c];
+  data_list_[id].assign(data, data + data_length_);
 
   is_param_changed_   = true;
   return true;
@@ -83,7 +77,6 @@ void GroupSyncWrite::removeParam(uint8_t id)
     return;
 
   id_list_.erase(it);
-  delete[] data_list_[id];
   data_list_.erase(id);
 
   is_param_changed_   = true;
@@ -95,10 +88,7 @@ bool GroupSyncWrite::changeParam(uint8_t id, uint8_t *data)
   if (it == id_list_.end())    // NOT exist
     return false;
 
-  delete[] data_list_[id];
-  data_list_[id]    = new uint8_t[data_length_];
-  for (int c = 0; c < data_length_; c++)
-    data_list_[id][c] = data[c];
+  data_list_[id].assign(data, data + data_length_);
 
   is_param_changed_   = true;
   return true;
@@ -106,26 +96,21 @@ bool GroupSyncWrite::changeParam(uint8_t id, uint8_t *data)
 
 void GroupSyncWrite::clearParam()
 {
-  if (id_list_.size() == 0)
+  if (id_list_.empty())
     return;
-
-  for (unsigned int i = 0; i < id_list_.size(); i++)
-    delete[] data_list_[id_list_[i]];
 
   id_list_.clear();
   data_list_.clear();
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
+  param_.clear();
 }
 
 int GroupSyncWrite::txPacket()
 {
-  if (id_list_.size() == 0)
+  if (id_list_.empty())
     return COMM_NOT_AVAILABLE;
 
-  if (is_param_changed_ == true || param_ == 0)
+  if (is_param_changed_ == true || param_.empty())
     makeParam();
 
-  return ph_->syncWriteTxOnly(port_, start_address_, data_length_, param_, id_list_.size() * (1 + data_length_));
+  return ph_->syncWriteTxOnly(port_, start_address_, data_length_, param_.data(), id_list_.size() * (1 + data_length_));
 }

--- a/c++/src/dynamixel_sdk/group_sync_write.cpp
+++ b/c++/src/dynamixel_sdk/group_sync_write.cpp
@@ -112,5 +112,11 @@ int GroupSyncWrite::txPacket()
   if (is_param_changed_ == true || param_.empty())
     makeParam();
 
-  return ph_->syncWriteTxOnly(port_, start_address_, data_length_, param_.data(), id_list_.size() * (1 + data_length_));
+  if (param_.size() != id_list_.size() * (1 + data_length_) ||
+      param_.size() > 0xFFFFu)
+    return COMM_TX_ERROR;
+
+  return ph_->syncWriteTxOnly(
+      port_, start_address_, data_length_, param_.data(),
+      static_cast<uint16_t>(param_.size()));
 }

--- a/c++/src/dynamixel_sdk/packet_handler.cpp
+++ b/c++/src/dynamixel_sdk/packet_handler.cpp
@@ -41,12 +41,12 @@ PacketHandler *PacketHandler::getPacketHandler(float protocol_version)
 {
   if (protocol_version == 1.0)
   {
-    return (PacketHandler *)(Protocol1PacketHandler::getInstance());
+    return Protocol1PacketHandler::getInstance();
   }
   else if (protocol_version == 2.0)
   {
-    return (PacketHandler *)(Protocol2PacketHandler::getInstance());
+    return Protocol2PacketHandler::getInstance();
   }
 
-  return (PacketHandler *)(Protocol2PacketHandler::getInstance());
+  return Protocol2PacketHandler::getInstance();
 }

--- a/c++/src/dynamixel_sdk/port_handler.cpp
+++ b/c++/src/dynamixel_sdk/port_handler.cpp
@@ -36,12 +36,12 @@ using namespace dynamixel;
 PortHandler *PortHandler::getPortHandler(const char *port_name)
 {
 #if defined(__linux__)
-  return (PortHandler *)(new PortHandlerLinux(port_name));
+  return static_cast<PortHandler*>(new PortHandlerLinux(port_name));
 #elif defined(__APPLE__)
-  return (PortHandler *)(new PortHandlerMac(port_name));
+  return static_cast<PortHandler*>(new PortHandlerMac(port_name));
 #elif defined(_WIN32) || defined(_WIN64)
-  return (PortHandler *)(new PortHandlerWindows(port_name));
+  return static_cast<PortHandler*>(new PortHandlerWindows(port_name));
 #elif defined(ARDUINO) || defined(__OPENCR__) || defined(__OPENCM904__) || defined(ARDUINO_OpenRB)
-  return (PortHandler *)(new PortHandlerArduino(port_name));
+  return static_cast<PortHandler*>(new PortHandlerArduino(port_name));
 #endif
 }

--- a/c++/src/dynamixel_sdk/port_handler_arduino.cpp
+++ b/c++/src/dynamixel_sdk/port_handler_arduino.cpp
@@ -97,12 +97,12 @@ void PortHandlerArduino::clearPort()
 {
   int temp __attribute__((unused));
 #if defined(__OPENCR__) || defined(ARDUINO_OpenRB)
-  while (DYNAMIXEL_SERIAL.available()) 
+  while (DYNAMIXEL_SERIAL.available())
   {
       temp = DYNAMIXEL_SERIAL.read();
   }
 #elif defined(__OPENCM904__)
-  while (p_dxl_serial->available()) 
+  while (p_dxl_serial->available())
   {
       temp = p_dxl_serial->read();
   }
@@ -194,7 +194,7 @@ int PortHandlerArduino::writePort(uint8_t *packet, int length)
 void PortHandlerArduino::setPacketTimeout(uint16_t packet_length)
 {
   packet_start_time_  = getCurrentTime();
-  packet_timeout_     = (tx_time_per_byte * (double)packet_length) + (LATENCY_TIMER * 2.0) + 2.0;
+  packet_timeout_     = (tx_time_per_byte * static_cast<double>(packet_length)) + (LATENCY_TIMER * 2.0) + 2.0;
 }
 
 void PortHandlerArduino::setPacketTimeout(double msec)
@@ -216,7 +216,7 @@ bool PortHandlerArduino::isPacketTimeout()
 
 double PortHandlerArduino::getCurrentTime()
 {
-  return (double)millis();
+  return static_cast<double>(millis());
 }
 
 double PortHandlerArduino::getTimeSinceStart()
@@ -241,7 +241,7 @@ bool PortHandlerArduino::setupPort(int baudrate)
 
   delay(100);
 
-  tx_time_per_byte = (1000.0 / (double)baudrate) * 10.0;
+  tx_time_per_byte = (1000.0 / static_cast<double>(baudrate)) * 10.0;
   return true;
 }
 

--- a/c++/src/dynamixel_sdk/port_handler_linux.cpp
+++ b/c++/src/dynamixel_sdk/port_handler_linux.cpp
@@ -161,7 +161,7 @@ int PortHandlerLinux::writePort(uint8_t *packet, int length)
 void PortHandlerLinux::setPacketTimeout(uint16_t packet_length)
 {
   packet_start_time_  = getCurrentTime();
-  packet_timeout_     = (tx_time_per_byte * (double)packet_length) + (LATENCY_TIMER * 2.0) + 2.0;
+  packet_timeout_     = (tx_time_per_byte * static_cast<double>(packet_length)) + (LATENCY_TIMER * 2.0) + 2.0;
 }
 
 void PortHandlerLinux::setPacketTimeout(double msec)
@@ -184,7 +184,7 @@ double PortHandlerLinux::getCurrentTime()
 {
 	struct timespec tv;
 	clock_gettime(CLOCK_REALTIME, &tv);
-	return ((double)tv.tv_sec * 1000.0 + (double)tv.tv_nsec * 0.001 * 0.001);
+	return (static_cast<double>(tv.tv_sec) * 1000.0 + static_cast<double>(tv.tv_nsec) * 0.001 * 0.001);
 }
 
 double PortHandlerLinux::getTimeSinceStart()
@@ -209,7 +209,7 @@ bool PortHandlerLinux::setupPort(int cflag_baud)
     return false;
   }
 
-  bzero(&newtio, sizeof(newtio)); // clear struct for new port settings
+  memset(&newtio, 0, sizeof(newtio)); // clear struct for new port settings
 
   newtio.c_cflag = cflag_baud | CS8 | CLOCAL | CREAD;
   newtio.c_iflag = IGNPAR;
@@ -222,7 +222,7 @@ bool PortHandlerLinux::setupPort(int cflag_baud)
   tcflush(socket_fd_, TCIFLUSH);
   tcsetattr(socket_fd_, TCSANOW, &newtio);
 
-  tx_time_per_byte = (1000.0 / (double)baudrate_) * 10.0;
+  tx_time_per_byte = (1000.0 / static_cast<double>(baudrate_)) * 10.0;
   return true;
 }
 
@@ -265,7 +265,7 @@ bool PortHandlerLinux::setCustomBaudrate(int speed)
     return false;
   }
 
-  tx_time_per_byte = (1000.0 / (double)speed) * 10.0;
+  tx_time_per_byte = (1000.0 / static_cast<double>(speed)) * 10.0;
   return true;
 }
 

--- a/c++/src/dynamixel_sdk/port_handler_mac.cpp
+++ b/c++/src/dynamixel_sdk/port_handler_mac.cpp
@@ -129,8 +129,8 @@ int PortHandlerMac::writePort(uint8_t *packet, int length)
   while (unsent > 0) {
     ioctl(socket_fd_, TIOCOUTQ, &unsent);
   }
-  unsigned int tx_time = ((float)(length * 10) / baudrate_) * 1000000000;
-  struct timespec delay = {0, tx_time};
+  unsigned int tx_time = (static_cast<float>(length * 10) / baudrate_) * 1000000000;
+  struct timespec delay = {0, static_cast<long>(tx_time)};
   nanosleep(&delay, NULL);
 
   return result;
@@ -139,7 +139,7 @@ int PortHandlerMac::writePort(uint8_t *packet, int length)
 void PortHandlerMac::setPacketTimeout(uint16_t packet_length)
 {
   packet_start_time_  = getCurrentTime();
-  packet_timeout_     = (tx_time_per_byte * (double)packet_length) + (LATENCY_TIMER * 2.0) + 2.0;
+  packet_timeout_     = (tx_time_per_byte * static_cast<double>(packet_length)) + (LATENCY_TIMER * 2.0) + 2.0;
 }
 
 void PortHandlerMac::setPacketTimeout(double msec)
@@ -172,7 +172,7 @@ double PortHandlerMac::getCurrentTime()
 #else
   clock_gettime(CLOCK_REALTIME, &tv);
 #endif
-  return ((double)tv.tv_sec * 1000.0 + (double)tv.tv_nsec * 0.001 * 0.001);
+  return (static_cast<double>(tv.tv_sec) * 1000.0 + static_cast<double>(tv.tv_nsec) * 0.001 * 0.001);
 }
 
 double PortHandlerMac::getTimeSinceStart()
@@ -212,7 +212,7 @@ bool PortHandlerMac::setupPort(int cflag_baud)
   tcflush(socket_fd_, TCIFLUSH);
   tcsetattr(socket_fd_, TCSANOW, &newtio);
 
-  tx_time_per_byte = (1000.0 / (double)baudrate_) * 10.0;
+  tx_time_per_byte = (1000.0 / static_cast<double>(baudrate_)) * 10.0;
   return true;
 }
 

--- a/c++/src/dynamixel_sdk/port_handler_windows.cpp
+++ b/c++/src/dynamixel_sdk/port_handler_windows.cpp
@@ -98,8 +98,8 @@ int PortHandlerWindows::getBytesAvailable()
   DWORD retbyte = 2;
   BOOL res = DeviceIoControl(serial_handle_, GENERIC_READ | GENERIC_WRITE, NULL, 0, 0, 0, &retbyte, (LPOVERLAPPED)NULL);
 
-  printf("%d", (int)res);
-  return (int)retbyte;
+  printf("%d", static_cast<int>(res));
+  return static_cast<int>(retbyte);
 }
 
 int PortHandlerWindows::readPort(uint8_t *packet, int length)
@@ -109,7 +109,7 @@ int PortHandlerWindows::readPort(uint8_t *packet, int length)
   if (ReadFile(serial_handle_, packet, (DWORD)length, &dwRead, NULL) == FALSE)
     return -1;
 
-  return (int)dwRead;
+  return static_cast<int>(dwRead);
 }
 
 int PortHandlerWindows::writePort(uint8_t *packet, int length)
@@ -119,13 +119,13 @@ int PortHandlerWindows::writePort(uint8_t *packet, int length)
   if (WriteFile(serial_handle_, packet, (DWORD)length, &dwWrite, NULL) == FALSE)
     return -1;
 
-  return (int)dwWrite;
+  return static_cast<int>(dwWrite);
 }
 
 void PortHandlerWindows::setPacketTimeout(uint16_t packet_length)
 {
   packet_start_time_ = getCurrentTime();
-  packet_timeout_ = (tx_time_per_byte_ * (double)packet_length) + (LATENCY_TIMER * 2.0) + 2.0;
+  packet_timeout_ = (tx_time_per_byte_ * static_cast<double>(packet_length)) + (LATENCY_TIMER * 2.0) + 2.0;
 }
 
 void PortHandlerWindows::setPacketTimeout(double msec)
@@ -148,7 +148,7 @@ double PortHandlerWindows::getCurrentTime()
 {
   QueryPerformanceCounter(&counter_);
   QueryPerformanceFrequency(&freq_);
-  return (double)counter_.QuadPart / (double)freq_.QuadPart * 1000.0;
+  return static_cast<double>(counter_.QuadPart) / static_cast<double>(freq_.QuadPart) * 1000.0;
 }
 
 double PortHandlerWindows::getTimeSinceStart()
@@ -224,7 +224,7 @@ bool PortHandlerWindows::setupPort(int baudrate)
   if (SetCommTimeouts(serial_handle_, &timeouts) == FALSE)
     goto DXL_HAL_OPEN_ERROR;
 
-  tx_time_per_byte_ = (1000.0 / (double)baudrate_) * 10.0;
+  tx_time_per_byte_ = (1000.0 / static_cast<double>(baudrate_)) * 10.0;
   return true;
 
 DXL_HAL_OPEN_ERROR:

--- a/c++/src/dynamixel_sdk/protocol1_packet_handler.cpp
+++ b/c++/src/dynamixel_sdk/protocol1_packet_handler.cpp
@@ -16,6 +16,9 @@
 
 /* Author: zerom, Ryu Woon Jung (Leon) */
 
+#include <vector>
+#include <algorithm>
+
 #if defined(__linux__)
 #include "protocol1_packet_handler.h"
 #elif defined(__APPLE__)
@@ -29,6 +32,11 @@
 
 #include <string.h>
 #include <stdlib.h>
+
+namespace {
+  thread_local std::vector<uint8_t> g_txpacket_buffer;
+  thread_local std::vector<uint8_t> g_rxpacket_buffer;
+}
 
 #define TXPACKET_MAX_LEN    (250)
 #define RXPACKET_MAX_LEN    (250)
@@ -293,11 +301,11 @@ int Protocol1PacketHandler::txRxPacket(PortHandler *port, uint8_t *txpacket, uin
   // set packet timeout
   if (txpacket[PKT_INSTRUCTION] == INST_READ)
   {
-    port->setPacketTimeout((uint16_t)(txpacket[PKT_PARAMETER0+1] + 6));
+    port->setPacketTimeout(static_cast<uint16_t>(txpacket[PKT_PARAMETER0+1] + 6));
   }
   else
   {
-    port->setPacketTimeout((uint16_t)6); // HEADER0 HEADER1 ID LENGTH ERROR CHECKSUM
+    port->setPacketTimeout(static_cast<uint16_t>(6)); // HEADER0 HEADER1 ID LENGTH ERROR CHECKSUM
   }
 
   // rx packet
@@ -308,7 +316,7 @@ int Protocol1PacketHandler::txRxPacket(PortHandler *port, uint8_t *txpacket, uin
   if (result == COMM_SUCCESS && txpacket[PKT_ID] == rxpacket[PKT_ID])
   {
     if (error != 0)
-      *error = (uint8_t)rxpacket[PKT_ERROR];
+      *error = rxpacket[PKT_ERROR];
   }
 
   return result;
@@ -399,14 +407,14 @@ int Protocol1PacketHandler::readTx(PortHandler *port, uint8_t id, uint16_t addre
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = 4;
   txpacket[PKT_INSTRUCTION]   = INST_READ;
-  txpacket[PKT_PARAMETER0+0]  = (uint8_t)address;
-  txpacket[PKT_PARAMETER0+1]  = (uint8_t)length;
+  txpacket[PKT_PARAMETER0+0]  = static_cast<uint8_t>(address);
+  txpacket[PKT_PARAMETER0+1]  = static_cast<uint8_t>(length);
 
   result = txPacket(port, txpacket);
 
   // set packet timeout
   if (result == COMM_SUCCESS)
-    port->setPacketTimeout((uint16_t)(length+6));
+    port->setPacketTimeout(static_cast<uint16_t>(length+6));
 
   return result;
 }
@@ -414,21 +422,21 @@ int Protocol1PacketHandler::readTx(PortHandler *port, uint8_t id, uint16_t addre
 int Protocol1PacketHandler::readRx(PortHandler *port, uint8_t id, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-  uint8_t *rxpacket           = (uint8_t *)malloc(RXPACKET_MAX_LEN); //(length+6);
-  //uint8_t *rxpacket         = new uint8_t[length+6];
 
-  if (rxpacket == NULL)
-    return result;
+  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
+    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
+  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
+  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
 
   do {
-    result = rxPacket(port, rxpacket);
+    result = rxPacket(port, rxpacket.data());
   } while (result == COMM_SUCCESS && rxpacket[PKT_ID] != id);
 
   if (result == COMM_SUCCESS && rxpacket[PKT_ID] == id)
   {
     if (error != 0)
     {
-      *error = (uint8_t)rxpacket[PKT_ERROR];
+      *error = rxpacket[PKT_ERROR];
     }
     for (uint16_t s = 0; s < length; s++)
     {
@@ -437,8 +445,6 @@ int Protocol1PacketHandler::readRx(PortHandler *port, uint8_t id, uint16_t lengt
     //memcpy(data, &rxpacket[PKT_PARAMETER0], length);
   }
 
-  free(rxpacket);
-  //delete[] rxpacket;
   return result;
 }
 
@@ -447,29 +453,29 @@ int Protocol1PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
   int result = COMM_TX_FAIL;
 
   uint8_t txpacket[8]         = {0};
-  uint8_t *rxpacket           = (uint8_t *)malloc(RXPACKET_MAX_LEN);//(length+6);
 
-  if (rxpacket == NULL)
-    return result;
+  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
+    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
+  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
+  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
 
   if (id >= BROADCAST_ID)
   {
-    free(rxpacket);
     return COMM_NOT_AVAILABLE;
   }
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = 4;
   txpacket[PKT_INSTRUCTION]   = INST_READ;
-  txpacket[PKT_PARAMETER0+0]  = (uint8_t)address;
-  txpacket[PKT_PARAMETER0+1]  = (uint8_t)length;
+  txpacket[PKT_PARAMETER0+0]  = static_cast<uint8_t>(address);
+  txpacket[PKT_PARAMETER0+1]  = static_cast<uint8_t>(length);
 
-  result = txRxPacket(port, txpacket, rxpacket, error);
+  result = txRxPacket(port, txpacket, rxpacket.data(), error);
   if (result == COMM_SUCCESS)
   {
     if (error != 0)
     {
-      *error = (uint8_t)rxpacket[PKT_ERROR];
+      *error = rxpacket[PKT_ERROR];
     }
     for (uint16_t s = 0; s < length; s++)
     {
@@ -478,8 +484,6 @@ int Protocol1PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
     //memcpy(data, &rxpacket[PKT_PARAMETER0], length);
   }
 
-  free(rxpacket);
-  //delete[] rxpacket;
   return result;
 }
 
@@ -550,26 +554,23 @@ int Protocol1PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t 
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(length+7);
-  //uint8_t *txpacket           = new uint8_t[length+7];
-
-  if (txpacket == NULL)
-    return result;
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 7))
+    g_txpacket_buffer.reserve(length + 7);
+  g_txpacket_buffer.resize(length + 7);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
   txpacket[PKT_INSTRUCTION]   = INST_WRITE;
-  txpacket[PKT_PARAMETER0]    = (uint8_t)address;
+  txpacket[PKT_PARAMETER0]    = static_cast<uint8_t>(address);
 
   for (uint16_t s = 0; s < length; s++)
     txpacket[PKT_PARAMETER0+1+s] = data[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], data, length);
 
-  result = txPacket(port, txpacket);
+  result = txPacket(port, txpacket.data());
   port->is_using_ = false;
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -577,26 +578,23 @@ int Protocol1PacketHandler::writeTxRx(PortHandler *port, uint8_t id, uint16_t ad
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(length+7); //#6->7
-  //uint8_t *txpacket           = new uint8_t[length+7];
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 7))
+    g_txpacket_buffer.reserve(length + 7);
+  g_txpacket_buffer.resize(length + 7);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
   uint8_t rxpacket[6]         = {0};
-
-  if (txpacket == NULL)
-    return result;
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
   txpacket[PKT_INSTRUCTION]   = INST_WRITE;
-  txpacket[PKT_PARAMETER0]    = (uint8_t)address;
+  txpacket[PKT_PARAMETER0]    = static_cast<uint8_t>(address);
 
   for (uint16_t s = 0; s < length; s++)
     txpacket[PKT_PARAMETER0+1+s] = data[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], data, length);
 
-  result = txRxPacket(port, txpacket, rxpacket, error);
+  result = txRxPacket(port, txpacket.data(), rxpacket, error);
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -637,26 +635,23 @@ int Protocol1PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(length+6);
-  //uint8_t *txpacket           = new uint8_t[length+6];
-
-  if (txpacket == NULL)
-    return result;
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 6))
+    g_txpacket_buffer.reserve(length + 6);
+  g_txpacket_buffer.resize(length + 6);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
   txpacket[PKT_INSTRUCTION]   = INST_REG_WRITE;
-  txpacket[PKT_PARAMETER0]    = (uint8_t)address;
+  txpacket[PKT_PARAMETER0]    = static_cast<uint8_t>(address);
 
   for (uint16_t s = 0; s < length; s++)
     txpacket[PKT_PARAMETER0+1+s] = data[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], data, length);
 
-  result = txPacket(port, txpacket);
+  result = txPacket(port, txpacket.data());
   port->is_using_ = false;
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -664,26 +659,23 @@ int Protocol1PacketHandler::regWriteTxRx(PortHandler *port, uint8_t id, uint16_t
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(length+6);
-  //uint8_t *txpacket           = new uint8_t[length+6];
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 6))
+    g_txpacket_buffer.reserve(length + 6);
+  g_txpacket_buffer.resize(length + 6);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
   uint8_t rxpacket[6]         = {0};
-
-  if (txpacket == NULL)
-    return result;
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
   txpacket[PKT_INSTRUCTION]   = INST_REG_WRITE;
-  txpacket[PKT_PARAMETER0]    = (uint8_t)address;
+  txpacket[PKT_PARAMETER0]    = static_cast<uint8_t>(address);
 
   for (uint16_t s = 0; s < length; s++)
     txpacket[PKT_PARAMETER0+1+s] = data[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], data, length);
 
-  result = txRxPacket(port, txpacket, rxpacket, error);
+  result = txRxPacket(port, txpacket.data(), rxpacket, error);
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -696,12 +688,11 @@ int Protocol1PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(param_length+8);
   // 8: HEADER0 HEADER1 ID LEN INST START_ADDR DATA_LEN ... CHKSUM
-  //uint8_t *txpacket           = new uint8_t[param_length + 8];
-
-  if (txpacket == NULL)
-    return result;
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 8))
+    g_txpacket_buffer.reserve(param_length + 8);
+  g_txpacket_buffer.resize(param_length + 8);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH]        = param_length + 4; // 4: INST START_ADDR DATA_LEN ... CHKSUM
@@ -713,10 +704,8 @@ int Protocol1PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
     txpacket[PKT_PARAMETER0+2+s] = param[s];
   //memcpy(&txpacket[PKT_PARAMETER0+2], param, param_length);
 
-  result = txRxPacket(port, txpacket, 0, 0);
+  result = txRxPacket(port, txpacket.data(), 0, 0);
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -724,12 +713,11 @@ int Protocol1PacketHandler::bulkReadTx(PortHandler *port, uint8_t *param, uint16
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(param_length+7);
   // 7: HEADER0 HEADER1 ID LEN INST 0x00 ... CHKSUM
-  //uint8_t *txpacket           = new uint8_t[param_length + 7];
-
-  if (txpacket == NULL)
-    return result;
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 7))
+    g_txpacket_buffer.reserve(param_length + 7);
+  g_txpacket_buffer.resize(param_length + 7);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH]        = param_length + 3; // 3: INST 0x00 ... CHKSUM
@@ -740,17 +728,15 @@ int Protocol1PacketHandler::bulkReadTx(PortHandler *port, uint8_t *param, uint16
     txpacket[PKT_PARAMETER0+1+s] = param[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], param, param_length);
 
-  result = txPacket(port, txpacket);
+  result = txPacket(port, txpacket.data());
   if (result == COMM_SUCCESS)
   {
     int wait_length = 0;
     for (uint16_t i = 0; i < param_length; i += 3)
       wait_length += param[i] + 7;
-    port->setPacketTimeout((uint16_t)wait_length);
+    port->setPacketTimeout(static_cast<uint16_t>(wait_length));
   }
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 

--- a/c++/src/dynamixel_sdk/protocol1_packet_handler.cpp
+++ b/c++/src/dynamixel_sdk/protocol1_packet_handler.cpp
@@ -33,11 +33,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-namespace {
-  thread_local std::vector<uint8_t> g_txpacket_buffer;
-  thread_local std::vector<uint8_t> g_rxpacket_buffer;
-}
-
 #define TXPACKET_MAX_LEN    (250)
 #define RXPACKET_MAX_LEN    (250)
 
@@ -422,11 +417,7 @@ int Protocol1PacketHandler::readTx(PortHandler *port, uint8_t id, uint16_t addre
 int Protocol1PacketHandler::readRx(PortHandler *port, uint8_t id, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
-    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
-  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
-  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
+  std::vector<uint8_t> rxpacket(RXPACKET_MAX_LEN);
 
   do {
     result = rxPacket(port, rxpacket.data());
@@ -453,11 +444,7 @@ int Protocol1PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
   int result = COMM_TX_FAIL;
 
   uint8_t txpacket[8]         = {0};
-
-  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
-    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
-  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
-  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
+  std::vector<uint8_t> rxpacket(RXPACKET_MAX_LEN);
 
   if (id >= BROADCAST_ID)
   {
@@ -553,11 +540,7 @@ int Protocol1PacketHandler::read4ByteTxRx(PortHandler *port, uint8_t id, uint16_
 int Protocol1PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data)
 {
   int result                 = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 7))
-    g_txpacket_buffer.reserve(length + 7);
-  g_txpacket_buffer.resize(length + 7);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 7);
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
@@ -577,11 +560,7 @@ int Protocol1PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t 
 int Protocol1PacketHandler::writeTxRx(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                 = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 7))
-    g_txpacket_buffer.reserve(length + 7);
-  g_txpacket_buffer.resize(length + 7);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 7);
   uint8_t rxpacket[6]         = {0};
 
   txpacket[PKT_ID]            = id;
@@ -634,11 +613,7 @@ int Protocol1PacketHandler::write4ByteTxRx(PortHandler *port, uint8_t id, uint16
 int Protocol1PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data)
 {
   int result                 = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 6))
-    g_txpacket_buffer.reserve(length + 6);
-  g_txpacket_buffer.resize(length + 6);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 6);
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
@@ -658,11 +633,7 @@ int Protocol1PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16
 int Protocol1PacketHandler::regWriteTxRx(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                 = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 6))
-    g_txpacket_buffer.reserve(length + 6);
-  g_txpacket_buffer.resize(length + 6);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 6);
   uint8_t rxpacket[6]         = {0};
 
   txpacket[PKT_ID]            = id;
@@ -689,10 +660,7 @@ int Protocol1PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
   int result                 = COMM_TX_FAIL;
 
   // 8: HEADER0 HEADER1 ID LEN INST START_ADDR DATA_LEN ... CHKSUM
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 8))
-    g_txpacket_buffer.reserve(param_length + 8);
-  g_txpacket_buffer.resize(param_length + 8);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 8);
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH]        = param_length + 4; // 4: INST START_ADDR DATA_LEN ... CHKSUM
@@ -714,10 +682,7 @@ int Protocol1PacketHandler::bulkReadTx(PortHandler *port, uint8_t *param, uint16
   int result                 = COMM_TX_FAIL;
 
   // 7: HEADER0 HEADER1 ID LEN INST 0x00 ... CHKSUM
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 7))
-    g_txpacket_buffer.reserve(param_length + 7);
-  g_txpacket_buffer.resize(param_length + 7);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 7);
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH]        = param_length + 3; // 3: INST 0x00 ... CHKSUM

--- a/c++/src/dynamixel_sdk/protocol2_packet_handler.cpp
+++ b/c++/src/dynamixel_sdk/protocol2_packet_handler.cpp
@@ -37,11 +37,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-namespace {
-  thread_local std::vector<uint8_t> g_txpacket_buffer;
-  thread_local std::vector<uint8_t> g_rxpacket_buffer;
-}
-
 #define TXPACKET_MAX_LEN    (1*1024)
 #define RXPACKET_MAX_LEN    (1*1024)
 
@@ -707,11 +702,7 @@ int Protocol2PacketHandler::readTx(PortHandler *port, uint8_t id, uint16_t addre
 int Protocol2PacketHandler::readRx(PortHandler *port, uint8_t id, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-  
-  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
-    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
-  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
-  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
+  std::vector<uint8_t> rxpacket(RXPACKET_MAX_LEN);
   
   do {
     result = rxPacket(port, rxpacket.data());
@@ -737,11 +728,7 @@ int Protocol2PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
   int result                  = COMM_TX_FAIL;
 
   uint8_t txpacket[14]        = {0};
-  
-  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
-    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
-  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
-  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
+  std::vector<uint8_t> rxpacket(RXPACKET_MAX_LEN);
 
   if (id >= BROADCAST_ID)
   {
@@ -840,11 +827,7 @@ int Protocol2PacketHandler::read4ByteTxRx(PortHandler *port, uint8_t id, uint16_
 int Protocol2PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 12 + (length / 3)))
-    g_txpacket_buffer.reserve(length + 12 + (length / 3));
-  g_txpacket_buffer.resize(length + 12 + (length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 12 + (length / 3));
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(length+5);
@@ -866,11 +849,7 @@ int Protocol2PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t 
 int Protocol2PacketHandler::writeTxRx(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 12 + (length / 3)))
-    g_txpacket_buffer.reserve(length + 12 + (length / 3));
-  g_txpacket_buffer.resize(length + 12 + (length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 12 + (length / 3));
   uint8_t rxpacket[11]        = {0};
 
   txpacket[PKT_ID]            = id;
@@ -925,11 +904,7 @@ int Protocol2PacketHandler::write4ByteTxRx(PortHandler *port, uint8_t id, uint16
 int Protocol2PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 12 + (length / 3)))
-    g_txpacket_buffer.reserve(length + 12 + (length / 3));
-  g_txpacket_buffer.resize(length + 12 + (length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 12 + (length / 3));
   
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(length+5);
@@ -951,11 +926,7 @@ int Protocol2PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16
 int Protocol2PacketHandler::regWriteTxRx(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 12 + (length / 3)))
-    g_txpacket_buffer.reserve(length + 12 + (length / 3));
-  g_txpacket_buffer.resize(length + 12 + (length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 12 + (length / 3));
   uint8_t rxpacket[11]        = {0};
 
   txpacket[PKT_ID]            = id;
@@ -979,10 +950,7 @@ int Protocol2PacketHandler::syncReadTx(PortHandler *port, uint16_t start_address
   int result                  = COMM_TX_FAIL;
 
   // 14: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 14 + (param_length / 3)))
-    g_txpacket_buffer.reserve(param_length + 14 + (param_length / 3));
-  g_txpacket_buffer.resize(param_length + 14 + (param_length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 14 + (param_length / 3));
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(param_length + 7); // 7: INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
@@ -1009,10 +977,7 @@ int Protocol2PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
   int result                  = COMM_TX_FAIL;
 
   // 14: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 14 + (param_length / 3)))
-    g_txpacket_buffer.reserve(param_length + 14 + (param_length / 3));
-  g_txpacket_buffer.resize(param_length + 14 + (param_length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 14 + (param_length / 3));
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(param_length + 7); // 7: INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
@@ -1037,10 +1002,7 @@ int Protocol2PacketHandler::bulkReadTx(PortHandler *port, uint8_t *param, uint16
   int result                  = COMM_TX_FAIL;
 
   // 10: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST CRC16_L CRC16_H
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 10 + (param_length / 3)))
-    g_txpacket_buffer.reserve(param_length + 10 + (param_length / 3));
-  g_txpacket_buffer.resize(param_length + 10 + (param_length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 10 + (param_length / 3));
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(param_length + 3); // 3: INST CRC16_L CRC16_H
@@ -1068,10 +1030,7 @@ int Protocol2PacketHandler::bulkWriteTxOnly(PortHandler *port, uint8_t *param, u
   int result                  = COMM_TX_FAIL;
 
   // 10: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST CRC16_L CRC16_H
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 10 + (param_length / 3)))
-    g_txpacket_buffer.reserve(param_length + 10 + (param_length / 3));
-  g_txpacket_buffer.resize(param_length + 10 + (param_length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 10 + (param_length / 3));
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(param_length + 3); // 3: INST CRC16_L CRC16_H
@@ -1092,10 +1051,7 @@ int Protocol2PacketHandler::fastSyncReadTx(PortHandler *port, uint16_t start_add
     int result = COMM_TX_FAIL;
 
     // 14: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
-    if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 14 + (param_length / 3)))
-        g_txpacket_buffer.reserve(param_length + 14 + (param_length / 3));
-    g_txpacket_buffer.resize(param_length + 14 + (param_length / 3));
-    std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+    std::vector<uint8_t> txpacket(param_length + 14 + (param_length / 3));
 
     txpacket[PKT_ID]             = BROADCAST_ID;
     txpacket[PKT_LENGTH_L]       = DXL_LOBYTE(param_length + 7); // 7: INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
@@ -1122,10 +1078,7 @@ int Protocol2PacketHandler::fastBulkReadTx(PortHandler *port, uint8_t *param, ui
     int result = COMM_TX_FAIL;
 
     // 10: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST CRC16_L CRC16_H
-    if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 10 + (param_length / 3)))
-        g_txpacket_buffer.reserve(param_length + 10 + (param_length / 3));
-    g_txpacket_buffer.resize(param_length + 10 + (param_length / 3));
-    std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+    std::vector<uint8_t> txpacket(param_length + 10 + (param_length / 3));
 
     txpacket[PKT_ID]          = BROADCAST_ID;
     txpacket[PKT_LENGTH_L]    = DXL_LOBYTE(param_length + 3); // 3: INST CRC16_L CRC16_H

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Standalone C SDK: configure/build from the c/ directory (paths below are relative to c/).
-project(dynamixel_sdk_c VERSION 4.0.4 LANGUAGES C)
+project(dynamixel_sdk_c VERSION 5.0.0 LANGUAGES C)
 
 # --------------------------------------------------------
 # 1. Build Environment Configuration
@@ -148,4 +148,3 @@ if(NOT TARGET reinstall)
     COMMENT "Reinstalling DynamixelSDK (C)..."
   )
 endif()
-

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Standalone C SDK: configure/build from the c/ directory (paths below are relative to c/).
-project(dynamixel_sdk_c VERSION 5.0.0 LANGUAGES C)
+project(dynamixel_sdk_c VERSION 4.1.0 LANGUAGES C)
 
 # --------------------------------------------------------
 # 1. Build Environment Configuration

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamixel-sdk"
-version = "4.0.4"
+version = "5.0.0"
 description = "Dynamixel SDK 4. python package"
 readme = "README.txt"
 license = { text = "Apache 2.0" }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamixel-sdk"
-version = "5.0.0"
+version = "4.1.0"
 description = "Dynamixel SDK 4. python package"
 readme = "README.txt"
 license = { text = "Apache 2.0" }

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ author_emails = ', '.join(email for _, email in authors_info)
 
 setup(
     name='dynamixel_sdk',
-    version='5.0.0',
+    version='4.1.0',
     packages=['dynamixel_sdk'],
     package_dir={'': 'src'},
     license='Apache 2.0',

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ author_emails = ', '.join(email for _, email in authors_info)
 
 setup(
     name='dynamixel_sdk',
-    version='4.0.4',
+    version='5.0.0',
     packages=['dynamixel_sdk'],
     package_dir={'': 'src'},
     license='Apache 2.0',

--- a/python/src/dynamixel_sdk/port_handler.py
+++ b/python/src/dynamixel_sdk/port_handler.py
@@ -48,7 +48,7 @@ class PortHandler(object):
         self.is_open = False
 
     def clearPort(self):
-        self.ser.flush()
+        self.ser.reset_input_buffer()
 
     def setPortName(self, port_name):
         self.port_name = port_name

--- a/ros/dynamixel_sdk/CHANGELOG.rst
+++ b/ros/dynamixel_sdk/CHANGELOG.rst
@@ -2,12 +2,12 @@
 Changelog for package dynamixel_sdk
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-5.0.0 (2026-04-09)
+4.1.0 (2026-04-14)
 ------------------
 * Updated the standalone C++ SDK and ROS 2 C++ wrappers to use safer dynamic storage for group and packet buffers
 * Bumped the C++ shared library ABI to SOVERSION 3 due to public C++ class layout changes
-* Added VERSION 5.0.0 and SOVERSION 3 to the ROS 2 shared library target for consistent ABI versioning
-* Unified package versioning to 5.0.0
+* Added VERSION 4.1.0 and SOVERSION 3 to the ROS 2 shared library target for consistent ABI versioning
+* Unified package versioning to 4.1.0
 * Contributors: Hyungyu Kim
 
 4.0.4 (2026-03-27)

--- a/ros/dynamixel_sdk/CHANGELOG.rst
+++ b/ros/dynamixel_sdk/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package dynamixel_sdk
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+5.0.0 (2026-04-09)
+------------------
+* Updated the standalone C++ SDK and ROS 2 C++ wrappers to use safer dynamic storage for group and packet buffers
+* Bumped the C++ shared library ABI to SOVERSION 3 due to public C++ class layout changes
+* Added VERSION 5.0.0 and SOVERSION 3 to the ROS 2 shared library target for consistent ABI versioning
+* Unified package versioning to 5.0.0
+* Contributors: Hyungyu Kim
+
 4.0.4 (2026-03-27)
 ------------------
 * None

--- a/ros/dynamixel_sdk/CMakeLists.txt
+++ b/ros/dynamixel_sdk/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Set minimum required version of cmake, project name and compile options
 ################################################################################
 cmake_minimum_required(VERSION 3.5)
-project(dynamixel_sdk VERSION 5.0.0)
+project(dynamixel_sdk VERSION 4.1.0)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)

--- a/ros/dynamixel_sdk/CMakeLists.txt
+++ b/ros/dynamixel_sdk/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Set minimum required version of cmake, project name and compile options
 ################################################################################
 cmake_minimum_required(VERSION 3.5)
-project(dynamixel_sdk)
+project(dynamixel_sdk VERSION 5.0.0)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
@@ -65,6 +65,11 @@ else()
     src/dynamixel_sdk/port_handler_linux.cpp
   )
 endif()
+
+set_target_properties(dynamixel_sdk PROPERTIES
+  VERSION ${PROJECT_VERSION}
+  SOVERSION 3
+)
 
 ################################################################################
 # Install

--- a/ros/dynamixel_sdk/include/dynamixel_sdk/group_bulk_read.h
+++ b/ros/dynamixel_sdk/include/dynamixel_sdk/group_bulk_read.h
@@ -38,7 +38,7 @@ class WINDECLSPEC GroupBulkRead : public GroupHandler
 protected:
     std::map<uint8_t, uint16_t> address_list_;  // <id, start_address>
     std::map<uint8_t, uint16_t> length_list_;   // <id, data_length>
-    std::map<uint8_t, uint8_t *> error_list_;   // <id, error>
+    std::map<uint8_t, std::vector<uint8_t>> error_list_;   // <id, error>
 
     bool last_result_;
 
@@ -135,7 +135,7 @@ public:
   /// @error error of Dynamixel
   /// @return true
   /// @return   when Dynamixel returned specific error byte
-  /// @return or false 
+  /// @return or false
   ////////////////////////////////////////////////////////////////////////////////
   bool        getError    (uint8_t id, uint8_t* error);
 };

--- a/ros/dynamixel_sdk/include/dynamixel_sdk/group_fast_bulk_read.h
+++ b/ros/dynamixel_sdk/include/dynamixel_sdk/group_fast_bulk_read.h
@@ -40,6 +40,7 @@ public:
 
 private:
     void makeParam();
+    std::vector<uint8_t> rxpacket_;
 };
 
 }

--- a/ros/dynamixel_sdk/include/dynamixel_sdk/group_fast_sync_read.h
+++ b/ros/dynamixel_sdk/include/dynamixel_sdk/group_fast_sync_read.h
@@ -37,6 +37,9 @@ public:
     int txPacket();
     int rxPacket();
     int txRxPacket();
+
+private:
+    std::vector<uint8_t> rxpacket_;
 };
 
 }

--- a/ros/dynamixel_sdk/include/dynamixel_sdk/group_handler.h
+++ b/ros/dynamixel_sdk/include/dynamixel_sdk/group_handler.h
@@ -44,11 +44,11 @@ protected:
     PacketHandler *ph_;
 
     std::vector<uint8_t> id_list_;
-    std::map<uint8_t, uint8_t *> data_list_;     // <id, data>
+    std::map<uint8_t, std::vector<uint8_t>> data_list_;     // <id, data>
 
     bool is_param_changed_;
 
-    uint8_t *param_;
+    std::vector<uint8_t> param_;
 };
 
 }

--- a/ros/dynamixel_sdk/include/dynamixel_sdk/group_sync_read.h
+++ b/ros/dynamixel_sdk/include/dynamixel_sdk/group_sync_read.h
@@ -36,7 +36,7 @@ namespace dynamixel
 class WINDECLSPEC GroupSyncRead : public GroupHandler
 {
 protected:
-    std::map<uint8_t, uint8_t *> error_list_; // <id, error>
+    std::map<uint8_t, std::vector<uint8_t>> error_list_; // <id, error>
 
     bool last_result_;
 
@@ -140,7 +140,7 @@ public:
   /// @error error of Dynamixel
   /// @return true
   /// @return   when Dynamixel returned specific error byte
-  /// @return or false 
+  /// @return or false
   ////////////////////////////////////////////////////////////////////////////////
   bool        getError    (uint8_t id, uint8_t* error);
 };

--- a/ros/dynamixel_sdk/include/dynamixel_sdk/packet_handler.h
+++ b/ros/dynamixel_sdk/include/dynamixel_sdk/packet_handler.h
@@ -39,12 +39,12 @@
 #define MAX_ID              0xFC    // 252
 
 /* Macro for Control Table Value */
-#define DXL_MAKEWORD(a, b)  ((uint16_t)(((uint8_t)(((uint64_t)(a)) & 0xff)) | ((uint16_t)((uint8_t)(((uint64_t)(b)) & 0xff))) << 8))
-#define DXL_MAKEDWORD(a, b) ((uint32_t)(((uint16_t)(((uint64_t)(a)) & 0xffff)) | ((uint32_t)((uint16_t)(((uint64_t)(b)) & 0xffff))) << 16))
-#define DXL_LOWORD(l)       ((uint16_t)(((uint64_t)(l)) & 0xffff))
-#define DXL_HIWORD(l)       ((uint16_t)((((uint64_t)(l)) >> 16) & 0xffff))
-#define DXL_LOBYTE(w)       ((uint8_t)(((uint64_t)(w)) & 0xff))
-#define DXL_HIBYTE(w)       ((uint8_t)((((uint64_t)(w)) >> 8) & 0xff))
+#define DXL_MAKEWORD(a, b)  (static_cast<uint16_t>((static_cast<uint8_t>(static_cast<uint64_t>(a) & 0xff)) | (static_cast<uint16_t>(static_cast<uint8_t>(static_cast<uint64_t>(b) & 0xff))) << 8))
+#define DXL_MAKEDWORD(a, b) (static_cast<uint32_t>((static_cast<uint16_t>(static_cast<uint64_t>(a) & 0xffff)) | (static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint64_t>(b) & 0xffff))) << 16))
+#define DXL_LOWORD(l)       (static_cast<uint16_t>(static_cast<uint64_t>(l) & 0xffff))
+#define DXL_HIWORD(l)       (static_cast<uint16_t>((static_cast<uint64_t>(l) >> 16) & 0xffff))
+#define DXL_LOBYTE(w)       (static_cast<uint8_t>(static_cast<uint64_t>(w) & 0xff))
+#define DXL_HIBYTE(w)       (static_cast<uint8_t>((static_cast<uint64_t>(w) >> 8) & 0xff))
 
 /* Instruction for DXL Protocol */
 #define INST_PING               1

--- a/ros/dynamixel_sdk/package.xml
+++ b/ros/dynamixel_sdk/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_sdk</name>
-  <version>5.0.0</version>
+  <version>4.1.0</version>
   <description>
     This package is wrapping version of ROBOTIS Dynamixel SDK for ROS 2. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.
   </description>

--- a/ros/dynamixel_sdk/package.xml
+++ b/ros/dynamixel_sdk/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_sdk</name>
-  <version>4.0.4</version>
+  <version>5.0.0</version>
   <description>
     This package is wrapping version of ROBOTIS Dynamixel SDK for ROS 2. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.
   </description>

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/group_bulk_write.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/group_bulk_write.cpp
@@ -40,33 +40,29 @@ GroupBulkWrite::GroupBulkWrite(PortHandler *port, PacketHandler *ph)
 
 void GroupBulkWrite::makeParam()
 {
-  if (ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
+  if (ph_->getProtocolVersion() == 1.0 || id_list_.empty())
     return;
-
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
 
   param_length_ = 0;
   for (unsigned int i = 0; i < id_list_.size(); i++)
     param_length_ += 1 + 2 + 2 + length_list_[id_list_[i]];
 
-  param_ = new uint8_t[param_length_];
+  param_.clear();
+  param_.reserve(param_length_);
 
-  int idx = 0;
   for (unsigned int i = 0; i < id_list_.size(); i++)
   {
     uint8_t id = id_list_[i];
-    if (data_list_[id] == 0)
+    if (data_list_.find(id) == data_list_.end())
       return;
 
-    param_[idx++] = id;
-    param_[idx++] = DXL_LOBYTE(address_list_[id]);
-    param_[idx++] = DXL_HIBYTE(address_list_[id]);
-    param_[idx++] = DXL_LOBYTE(length_list_[id]);
-    param_[idx++] = DXL_HIBYTE(length_list_[id]);
+    param_.push_back(id);
+    param_.push_back(DXL_LOBYTE(address_list_[id]));
+    param_.push_back(DXL_HIBYTE(address_list_[id]));
+    param_.push_back(DXL_LOBYTE(length_list_[id]));
+    param_.push_back(DXL_HIBYTE(length_list_[id]));
     for (int c = 0; c < length_list_[id]; c++)
-      param_[idx++] = (data_list_[id])[c];
+      param_.push_back((data_list_[id])[c]);
   }
 }
 
@@ -81,9 +77,7 @@ bool GroupBulkWrite::addParam(uint8_t id, uint16_t start_address, uint16_t data_
   id_list_.push_back(id);
   address_list_[id]   = start_address;
   length_list_[id]    = data_length;
-  data_list_[id]      = new uint8_t[data_length];
-  for (int c = 0; c < data_length; c++)
-    data_list_[id][c] = data[c];
+  data_list_[id].assign(data, data + data_length);
 
   is_param_changed_   = true;
   return true;
@@ -100,7 +94,6 @@ void GroupBulkWrite::removeParam(uint8_t id)
   id_list_.erase(it);
   address_list_.erase(id);
   length_list_.erase(id);
-  delete[] data_list_[id];
   data_list_.erase(id);
 
   is_param_changed_   = true;
@@ -116,37 +109,29 @@ bool GroupBulkWrite::changeParam(uint8_t id, uint16_t start_address, uint16_t da
 
   address_list_[id]   = start_address;
   length_list_[id]    = data_length;
-  delete[] data_list_[id];
-  data_list_[id]      = new uint8_t[data_length];
-  for (int c = 0; c < data_length; c++)
-    data_list_[id][c] = data[c];
+  data_list_[id].assign(data, data + data_length);
 
   is_param_changed_   = true;
   return true;
 }
 void GroupBulkWrite::clearParam()
 {
-  if (ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
+  if (ph_->getProtocolVersion() == 1.0 || id_list_.empty())
     return;
-
-  for (unsigned int i = 0; i < id_list_.size(); i++)
-    delete[] data_list_[id_list_[i]];
 
   id_list_.clear();
   address_list_.clear();
   length_list_.clear();
   data_list_.clear();
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
+  param_.clear();
 }
 int GroupBulkWrite::txPacket()
 {
-  if (ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
+  if (ph_->getProtocolVersion() == 1.0 || id_list_.empty())
     return COMM_NOT_AVAILABLE;
 
-  if (is_param_changed_ == true || param_ == 0)
+  if (is_param_changed_ == true || param_.empty())
     makeParam();
 
-  return ph_->bulkWriteTxOnly(port_, param_, param_length_);
+  return ph_->bulkWriteTxOnly(port_, param_.data(), param_length_);
 }

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/group_bulk_write.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/group_bulk_write.cpp
@@ -133,5 +133,10 @@ int GroupBulkWrite::txPacket()
   if (is_param_changed_ == true || param_.empty())
     makeParam();
 
-  return ph_->bulkWriteTxOnly(port_, param_.data(), param_length_);
+  if (param_.size() != static_cast<size_t>(param_length_) ||
+      param_.size() > 0xFFFFu)
+    return COMM_TX_ERROR;
+
+  return ph_->bulkWriteTxOnly(
+      port_, param_.data(), static_cast<uint16_t>(param_.size()));
 }

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/group_fast_bulk_read.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/group_fast_bulk_read.cpp
@@ -46,20 +46,16 @@ void GroupFastBulkRead::makeParam()
     if ((1.0 == ph_->getProtocolVersion()) || (id_list_.empty()))
         return;
 
-    if (0 != param_)
-        delete[] param_;
-    param_ = 0;
+    param_.clear();
+    param_.reserve(id_list_.size() * 5);
 
-    param_ = new uint8_t[id_list_.size() * 5];  // ID(1) + ADDR(2) + LENGTH(2)
-
-    int idx = 0;
     for (unsigned int i = 0; i < id_list_.size(); i++) {
         uint8_t id = id_list_[i];
-        param_[idx++] = id;                               // ID
-        param_[idx++] = DXL_LOBYTE(address_list_[id]);    // ADDR_L
-        param_[idx++] = DXL_HIBYTE(address_list_[id]);    // ADDR_H
-        param_[idx++] = DXL_LOBYTE(length_list_[id]);     // LEN_L
-        param_[idx++] = DXL_HIBYTE(length_list_[id]);     // LEN_H
+        param_.push_back(id);                               // ID
+        param_.push_back(DXL_LOBYTE(address_list_[id]));    // ADDR_L
+        param_.push_back(DXL_HIBYTE(address_list_[id]));    // ADDR_H
+        param_.push_back(DXL_LOBYTE(length_list_[id]));     // LEN_L
+        param_.push_back(DXL_HIBYTE(length_list_[id]));     // LEN_H
     }
 }
 
@@ -68,10 +64,10 @@ int GroupFastBulkRead::txPacket()
     if ((1.0 == ph_->getProtocolVersion()) || (id_list_.empty()))
         return COMM_NOT_AVAILABLE;
 
-    if ((true == is_param_changed_) || (0 == param_))
+    if ((true == is_param_changed_) || (param_.empty()))
         makeParam();
 
-    return ph_->fastBulkReadTx(port_, param_, id_list_.size() * 5);
+    return ph_->fastBulkReadTx(port_, param_.data(), id_list_.size() * 5);
 }
 
 int GroupFastBulkRead::rxPacket()
@@ -83,9 +79,9 @@ int GroupFastBulkRead::rxPacket()
 
     int count = id_list_.size();
     int result = COMM_RX_FAIL;
-    uint8_t *rxpacket = (uint8_t *)malloc(RXPACKET_MAX_LEN);
-    if (NULL == rxpacket)
-        return result;
+    if (rxpacket_.size() < static_cast<size_t>(RXPACKET_MAX_LEN))
+        rxpacket_.resize(static_cast<size_t>(RXPACKET_MAX_LEN));
+    uint8_t *rxpacket = rxpacket_.data();
 
     do {
         result = ph_->rxPacket(port_, rxpacket, true);
@@ -96,7 +92,7 @@ int GroupFastBulkRead::rxPacket()
         for (int i = 0; i < count; ++i) {
             uint8_t id = id_list_[i];
             uint16_t length = length_list_[id];
-            *error_list_[id] = (uint8_t)rxpacket[index];
+            error_list_[id][0] = static_cast<uint8_t>(rxpacket[index]);
             for (uint16_t s = 0; s < length; s++) {
                 data_list_[id][s] = rxpacket[index + 2 + s];
             }
@@ -105,7 +101,6 @@ int GroupFastBulkRead::rxPacket()
         last_result_ = true;
     }
 
-    free(rxpacket);
     return result;
 }
 

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/group_fast_sync_read.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/group_fast_sync_read.cpp
@@ -46,10 +46,10 @@ int GroupFastSyncRead::txPacket()
     if ((1.0 == ph_->getProtocolVersion()) || (id_list_.empty()))
         return COMM_NOT_AVAILABLE;
 
-    if ((true == is_param_changed_) || (0 == param_))
+    if ((true == is_param_changed_) || (param_.empty()))
         makeParam();
 
-    return ph_->fastSyncReadTx(port_, start_address_, data_length_, param_, (uint16_t)id_list_.size() * 1);
+    return ph_->fastSyncReadTx(port_, start_address_, data_length_, param_.data(), static_cast<uint16_t>(id_list_.size() * 1));
 }
 
 int GroupFastSyncRead::rxPacket()
@@ -61,9 +61,9 @@ int GroupFastSyncRead::rxPacket()
 
     int count = id_list_.size();
     int result = COMM_RX_FAIL;
-    uint8_t *rxpacket = (uint8_t *)malloc(RXPACKET_MAX_LEN);
-    if (NULL == rxpacket)
-        return result;
+    if (rxpacket_.size() < static_cast<size_t>(RXPACKET_MAX_LEN))
+        rxpacket_.resize(static_cast<size_t>(RXPACKET_MAX_LEN));
+    uint8_t *rxpacket = rxpacket_.data();
 
     do {
         result = ph_->rxPacket(port_, rxpacket, true);
@@ -73,7 +73,7 @@ int GroupFastSyncRead::rxPacket()
         int index = PKT_PARAMETER0;
         for (int i = 0; i < count; ++i) {
             uint8_t id = id_list_[i];
-            *error_list_[id] = (uint8_t)rxpacket[index];
+            error_list_[id][0] = static_cast<uint8_t>(rxpacket[index]);
             for (uint16_t s = 0; s < data_length_; s++) {
                 data_list_[id][s] = rxpacket[index + 2 + s];
             }
@@ -82,7 +82,6 @@ int GroupFastSyncRead::rxPacket()
         last_result_ = true;
     }
 
-    free(rxpacket);
     return result;
 }
 

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/group_handler.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/group_handler.cpp
@@ -32,8 +32,7 @@ using namespace dynamixel;
 GroupHandler::GroupHandler(PortHandler *port, PacketHandler *ph)
  : port_(port),
    ph_(ph),
-   is_param_changed_(false),
-   param_(0)
+   is_param_changed_(false)
 {
-
+  param_.clear();
 }

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/group_sync_write.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/group_sync_write.cpp
@@ -41,24 +41,20 @@ GroupSyncWrite::GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t st
 
 void GroupSyncWrite::makeParam()
 {
-  if (id_list_.size() == 0) return;
+  if (id_list_.empty()) return;
 
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
+  param_.clear();
+  param_.reserve(id_list_.size() * (1 + data_length_)); // ID(1) + DATA(data_length)
 
-  param_ = new uint8_t[id_list_.size() * (1 + data_length_)]; // ID(1) + DATA(data_length)
-
-  int idx = 0;
   for (unsigned int i = 0; i < id_list_.size(); i++)
   {
     uint8_t id = id_list_[i];
-    if (data_list_[id] == 0)
+    if (data_list_.find(id) == data_list_.end())
       return;
 
-    param_[idx++] = id;
+    param_.push_back(id);
     for (int c = 0; c < data_length_; c++)
-      param_[idx++] = (data_list_[id])[c];
+      param_.push_back((data_list_[id])[c]);
   }
 }
 
@@ -68,9 +64,7 @@ bool GroupSyncWrite::addParam(uint8_t id, uint8_t *data)
     return false;
 
   id_list_.push_back(id);
-  data_list_[id]    = new uint8_t[data_length_];
-  for (int c = 0; c < data_length_; c++)
-    data_list_[id][c] = data[c];
+  data_list_[id].assign(data, data + data_length_);
 
   is_param_changed_   = true;
   return true;
@@ -83,7 +77,6 @@ void GroupSyncWrite::removeParam(uint8_t id)
     return;
 
   id_list_.erase(it);
-  delete[] data_list_[id];
   data_list_.erase(id);
 
   is_param_changed_   = true;
@@ -95,10 +88,7 @@ bool GroupSyncWrite::changeParam(uint8_t id, uint8_t *data)
   if (it == id_list_.end())    // NOT exist
     return false;
 
-  delete[] data_list_[id];
-  data_list_[id]    = new uint8_t[data_length_];
-  for (int c = 0; c < data_length_; c++)
-    data_list_[id][c] = data[c];
+  data_list_[id].assign(data, data + data_length_);
 
   is_param_changed_   = true;
   return true;
@@ -106,26 +96,21 @@ bool GroupSyncWrite::changeParam(uint8_t id, uint8_t *data)
 
 void GroupSyncWrite::clearParam()
 {
-  if (id_list_.size() == 0)
+  if (id_list_.empty())
     return;
-
-  for (unsigned int i = 0; i < id_list_.size(); i++)
-    delete[] data_list_[id_list_[i]];
 
   id_list_.clear();
   data_list_.clear();
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
+  param_.clear();
 }
 
 int GroupSyncWrite::txPacket()
 {
-  if (id_list_.size() == 0)
+  if (id_list_.empty())
     return COMM_NOT_AVAILABLE;
 
-  if (is_param_changed_ == true || param_ == 0)
+  if (is_param_changed_ == true || param_.empty())
     makeParam();
 
-  return ph_->syncWriteTxOnly(port_, start_address_, data_length_, param_, id_list_.size() * (1 + data_length_));
+  return ph_->syncWriteTxOnly(port_, start_address_, data_length_, param_.data(), id_list_.size() * (1 + data_length_));
 }

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/group_sync_write.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/group_sync_write.cpp
@@ -112,5 +112,11 @@ int GroupSyncWrite::txPacket()
   if (is_param_changed_ == true || param_.empty())
     makeParam();
 
-  return ph_->syncWriteTxOnly(port_, start_address_, data_length_, param_.data(), id_list_.size() * (1 + data_length_));
+  if (param_.size() != id_list_.size() * (1 + data_length_) ||
+      param_.size() > 0xFFFFu)
+    return COMM_TX_ERROR;
+
+  return ph_->syncWriteTxOnly(
+      port_, start_address_, data_length_, param_.data(),
+      static_cast<uint16_t>(param_.size()));
 }

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/packet_handler.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/packet_handler.cpp
@@ -41,12 +41,12 @@ PacketHandler *PacketHandler::getPacketHandler(float protocol_version)
 {
   if (protocol_version == 1.0)
   {
-    return (PacketHandler *)(Protocol1PacketHandler::getInstance());
+    return Protocol1PacketHandler::getInstance();
   }
   else if (protocol_version == 2.0)
   {
-    return (PacketHandler *)(Protocol2PacketHandler::getInstance());
+    return Protocol2PacketHandler::getInstance();
   }
 
-  return (PacketHandler *)(Protocol2PacketHandler::getInstance());
+  return Protocol2PacketHandler::getInstance();
 }

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler.cpp
@@ -36,12 +36,12 @@ using namespace dynamixel;
 PortHandler *PortHandler::getPortHandler(const char *port_name)
 {
 #if defined(__linux__)
-  return (PortHandler *)(new PortHandlerLinux(port_name));
+  return static_cast<PortHandler*>(new PortHandlerLinux(port_name));
 #elif defined(__APPLE__)
-  return (PortHandler *)(new PortHandlerMac(port_name));
+  return static_cast<PortHandler*>(new PortHandlerMac(port_name));
 #elif defined(_WIN32) || defined(_WIN64)
-  return (PortHandler *)(new PortHandlerWindows(port_name));
+  return static_cast<PortHandler*>(new PortHandlerWindows(port_name));
 #elif defined(ARDUINO) || defined(__OPENCR__) || defined(__OPENCM904__) || defined(ARDUINO_OpenRB)
-  return (PortHandler *)(new PortHandlerArduino(port_name));
+  return static_cast<PortHandler*>(new PortHandlerArduino(port_name));
 #endif
 }

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler.py
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler.py
@@ -48,7 +48,7 @@ class PortHandler(object):
         self.is_open = False
 
     def clearPort(self):
-        self.ser.flush()
+        self.ser.reset_input_buffer()
 
     def setPortName(self, port_name):
         self.port_name = port_name

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_arduino.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_arduino.cpp
@@ -97,12 +97,12 @@ void PortHandlerArduino::clearPort()
 {
   int temp __attribute__((unused));
 #if defined(__OPENCR__) || defined(ARDUINO_OpenRB)
-  while (DYNAMIXEL_SERIAL.available()) 
+  while (DYNAMIXEL_SERIAL.available())
   {
       temp = DYNAMIXEL_SERIAL.read();
   }
 #elif defined(__OPENCM904__)
-  while (p_dxl_serial->available()) 
+  while (p_dxl_serial->available())
   {
       temp = p_dxl_serial->read();
   }
@@ -194,7 +194,7 @@ int PortHandlerArduino::writePort(uint8_t *packet, int length)
 void PortHandlerArduino::setPacketTimeout(uint16_t packet_length)
 {
   packet_start_time_  = getCurrentTime();
-  packet_timeout_     = (tx_time_per_byte * (double)packet_length) + (LATENCY_TIMER * 2.0) + 2.0;
+  packet_timeout_     = (tx_time_per_byte * static_cast<double>(packet_length)) + (LATENCY_TIMER * 2.0) + 2.0;
 }
 
 void PortHandlerArduino::setPacketTimeout(double msec)
@@ -216,7 +216,7 @@ bool PortHandlerArduino::isPacketTimeout()
 
 double PortHandlerArduino::getCurrentTime()
 {
-  return (double)millis();
+  return static_cast<double>(millis());
 }
 
 double PortHandlerArduino::getTimeSinceStart()
@@ -241,7 +241,7 @@ bool PortHandlerArduino::setupPort(int baudrate)
 
   delay(100);
 
-  tx_time_per_byte = (1000.0 / (double)baudrate) * 10.0;
+  tx_time_per_byte = (1000.0 / static_cast<double>(baudrate)) * 10.0;
   return true;
 }
 

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_linux.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_linux.cpp
@@ -161,7 +161,7 @@ int PortHandlerLinux::writePort(uint8_t *packet, int length)
 void PortHandlerLinux::setPacketTimeout(uint16_t packet_length)
 {
   packet_start_time_  = getCurrentTime();
-  packet_timeout_     = (tx_time_per_byte * (double)packet_length) + (LATENCY_TIMER * 2.0) + 2.0;
+  packet_timeout_     = (tx_time_per_byte * static_cast<double>(packet_length)) + (LATENCY_TIMER * 2.0) + 2.0;
 }
 
 void PortHandlerLinux::setPacketTimeout(double msec)
@@ -184,7 +184,7 @@ double PortHandlerLinux::getCurrentTime()
 {
 	struct timespec tv;
 	clock_gettime(CLOCK_REALTIME, &tv);
-	return ((double)tv.tv_sec * 1000.0 + (double)tv.tv_nsec * 0.001 * 0.001);
+	return (static_cast<double>(tv.tv_sec) * 1000.0 + static_cast<double>(tv.tv_nsec) * 0.001 * 0.001);
 }
 
 double PortHandlerLinux::getTimeSinceStart()
@@ -209,7 +209,7 @@ bool PortHandlerLinux::setupPort(int cflag_baud)
     return false;
   }
 
-  bzero(&newtio, sizeof(newtio)); // clear struct for new port settings
+  memset(&newtio, 0, sizeof(newtio)); // clear struct for new port settings
 
   newtio.c_cflag = cflag_baud | CS8 | CLOCAL | CREAD;
   newtio.c_iflag = IGNPAR;
@@ -222,7 +222,7 @@ bool PortHandlerLinux::setupPort(int cflag_baud)
   tcflush(socket_fd_, TCIFLUSH);
   tcsetattr(socket_fd_, TCSANOW, &newtio);
 
-  tx_time_per_byte = (1000.0 / (double)baudrate_) * 10.0;
+  tx_time_per_byte = (1000.0 / static_cast<double>(baudrate_)) * 10.0;
   return true;
 }
 
@@ -265,7 +265,7 @@ bool PortHandlerLinux::setCustomBaudrate(int speed)
     return false;
   }
 
-  tx_time_per_byte = (1000.0 / (double)speed) * 10.0;
+  tx_time_per_byte = (1000.0 / static_cast<double>(speed)) * 10.0;
   return true;
 }
 

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_mac.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_mac.cpp
@@ -129,8 +129,8 @@ int PortHandlerMac::writePort(uint8_t *packet, int length)
   while (unsent > 0) {
     ioctl(socket_fd_, TIOCOUTQ, &unsent);
   }
-  unsigned int tx_time = ((float)(length * 10) / baudrate_) * 1000000000;
-  struct timespec delay = {0, tx_time};
+  unsigned int tx_time = (static_cast<float>(length * 10) / baudrate_) * 1000000000;
+  struct timespec delay = {0, static_cast<long>(tx_time)};
   nanosleep(&delay, NULL);
 
   return result;
@@ -139,7 +139,7 @@ int PortHandlerMac::writePort(uint8_t *packet, int length)
 void PortHandlerMac::setPacketTimeout(uint16_t packet_length)
 {
   packet_start_time_  = getCurrentTime();
-  packet_timeout_     = (tx_time_per_byte * (double)packet_length) + (LATENCY_TIMER * 2.0) + 2.0;
+  packet_timeout_     = (tx_time_per_byte * static_cast<double>(packet_length)) + (LATENCY_TIMER * 2.0) + 2.0;
 }
 
 void PortHandlerMac::setPacketTimeout(double msec)
@@ -172,7 +172,7 @@ double PortHandlerMac::getCurrentTime()
 #else
   clock_gettime(CLOCK_REALTIME, &tv);
 #endif
-  return ((double)tv.tv_sec * 1000.0 + (double)tv.tv_nsec * 0.001 * 0.001);
+  return (static_cast<double>(tv.tv_sec) * 1000.0 + static_cast<double>(tv.tv_nsec) * 0.001 * 0.001);
 }
 
 double PortHandlerMac::getTimeSinceStart()
@@ -212,7 +212,7 @@ bool PortHandlerMac::setupPort(int cflag_baud)
   tcflush(socket_fd_, TCIFLUSH);
   tcsetattr(socket_fd_, TCSANOW, &newtio);
 
-  tx_time_per_byte = (1000.0 / (double)baudrate_) * 10.0;
+  tx_time_per_byte = (1000.0 / static_cast<double>(baudrate_)) * 10.0;
   return true;
 }
 

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_windows.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_windows.cpp
@@ -98,8 +98,8 @@ int PortHandlerWindows::getBytesAvailable()
   DWORD retbyte = 2;
   BOOL res = DeviceIoControl(serial_handle_, GENERIC_READ | GENERIC_WRITE, NULL, 0, 0, 0, &retbyte, (LPOVERLAPPED)NULL);
 
-  printf("%d", (int)res);
-  return (int)retbyte;
+  printf("%d", static_cast<int>(res));
+  return static_cast<int>(retbyte);
 }
 
 int PortHandlerWindows::readPort(uint8_t *packet, int length)
@@ -109,7 +109,7 @@ int PortHandlerWindows::readPort(uint8_t *packet, int length)
   if (ReadFile(serial_handle_, packet, (DWORD)length, &dwRead, NULL) == FALSE)
     return -1;
 
-  return (int)dwRead;
+  return static_cast<int>(dwRead);
 }
 
 int PortHandlerWindows::writePort(uint8_t *packet, int length)
@@ -119,13 +119,13 @@ int PortHandlerWindows::writePort(uint8_t *packet, int length)
   if (WriteFile(serial_handle_, packet, (DWORD)length, &dwWrite, NULL) == FALSE)
     return -1;
 
-  return (int)dwWrite;
+  return static_cast<int>(dwWrite);
 }
 
 void PortHandlerWindows::setPacketTimeout(uint16_t packet_length)
 {
   packet_start_time_ = getCurrentTime();
-  packet_timeout_ = (tx_time_per_byte_ * (double)packet_length) + (LATENCY_TIMER * 2.0) + 2.0;
+  packet_timeout_ = (tx_time_per_byte_ * static_cast<double>(packet_length)) + (LATENCY_TIMER * 2.0) + 2.0;
 }
 
 void PortHandlerWindows::setPacketTimeout(double msec)
@@ -148,7 +148,7 @@ double PortHandlerWindows::getCurrentTime()
 {
   QueryPerformanceCounter(&counter_);
   QueryPerformanceFrequency(&freq_);
-  return (double)counter_.QuadPart / (double)freq_.QuadPart * 1000.0;
+  return static_cast<double>(counter_.QuadPart) / static_cast<double>(freq_.QuadPart) * 1000.0;
 }
 
 double PortHandlerWindows::getTimeSinceStart()
@@ -224,7 +224,7 @@ bool PortHandlerWindows::setupPort(int baudrate)
   if (SetCommTimeouts(serial_handle_, &timeouts) == FALSE)
     goto DXL_HAL_OPEN_ERROR;
 
-  tx_time_per_byte_ = (1000.0 / (double)baudrate_) * 10.0;
+  tx_time_per_byte_ = (1000.0 / static_cast<double>(baudrate_)) * 10.0;
   return true;
 
 DXL_HAL_OPEN_ERROR:

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/protocol1_packet_handler.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/protocol1_packet_handler.cpp
@@ -16,6 +16,9 @@
 
 /* Author: zerom, Ryu Woon Jung (Leon) */
 
+#include <vector>
+#include <algorithm>
+
 #if defined(__linux__)
 #include "protocol1_packet_handler.h"
 #elif defined(__APPLE__)
@@ -29,6 +32,11 @@
 
 #include <string.h>
 #include <stdlib.h>
+
+namespace {
+  thread_local std::vector<uint8_t> g_txpacket_buffer;
+  thread_local std::vector<uint8_t> g_rxpacket_buffer;
+}
 
 #define TXPACKET_MAX_LEN    (250)
 #define RXPACKET_MAX_LEN    (250)
@@ -293,11 +301,11 @@ int Protocol1PacketHandler::txRxPacket(PortHandler *port, uint8_t *txpacket, uin
   // set packet timeout
   if (txpacket[PKT_INSTRUCTION] == INST_READ)
   {
-    port->setPacketTimeout((uint16_t)(txpacket[PKT_PARAMETER0+1] + 6));
+    port->setPacketTimeout(static_cast<uint16_t>(txpacket[PKT_PARAMETER0+1] + 6));
   }
   else
   {
-    port->setPacketTimeout((uint16_t)6); // HEADER0 HEADER1 ID LENGTH ERROR CHECKSUM
+    port->setPacketTimeout(static_cast<uint16_t>(6)); // HEADER0 HEADER1 ID LENGTH ERROR CHECKSUM
   }
 
   // rx packet
@@ -308,7 +316,7 @@ int Protocol1PacketHandler::txRxPacket(PortHandler *port, uint8_t *txpacket, uin
   if (result == COMM_SUCCESS && txpacket[PKT_ID] == rxpacket[PKT_ID])
   {
     if (error != 0)
-      *error = (uint8_t)rxpacket[PKT_ERROR];
+      *error = rxpacket[PKT_ERROR];
   }
 
   return result;
@@ -399,14 +407,14 @@ int Protocol1PacketHandler::readTx(PortHandler *port, uint8_t id, uint16_t addre
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = 4;
   txpacket[PKT_INSTRUCTION]   = INST_READ;
-  txpacket[PKT_PARAMETER0+0]  = (uint8_t)address;
-  txpacket[PKT_PARAMETER0+1]  = (uint8_t)length;
+  txpacket[PKT_PARAMETER0+0]  = static_cast<uint8_t>(address);
+  txpacket[PKT_PARAMETER0+1]  = static_cast<uint8_t>(length);
 
   result = txPacket(port, txpacket);
 
   // set packet timeout
   if (result == COMM_SUCCESS)
-    port->setPacketTimeout((uint16_t)(length+6));
+    port->setPacketTimeout(static_cast<uint16_t>(length+6));
 
   return result;
 }
@@ -414,21 +422,21 @@ int Protocol1PacketHandler::readTx(PortHandler *port, uint8_t id, uint16_t addre
 int Protocol1PacketHandler::readRx(PortHandler *port, uint8_t id, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-  uint8_t *rxpacket           = (uint8_t *)malloc(RXPACKET_MAX_LEN); //(length+6);
-  //uint8_t *rxpacket         = new uint8_t[length+6];
 
-  if (rxpacket == NULL)
-    return result;
+  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
+    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
+  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
+  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
 
   do {
-    result = rxPacket(port, rxpacket);
+    result = rxPacket(port, rxpacket.data());
   } while (result == COMM_SUCCESS && rxpacket[PKT_ID] != id);
 
   if (result == COMM_SUCCESS && rxpacket[PKT_ID] == id)
   {
     if (error != 0)
     {
-      *error = (uint8_t)rxpacket[PKT_ERROR];
+      *error = rxpacket[PKT_ERROR];
     }
     for (uint16_t s = 0; s < length; s++)
     {
@@ -437,8 +445,6 @@ int Protocol1PacketHandler::readRx(PortHandler *port, uint8_t id, uint16_t lengt
     //memcpy(data, &rxpacket[PKT_PARAMETER0], length);
   }
 
-  free(rxpacket);
-  //delete[] rxpacket;
   return result;
 }
 
@@ -447,29 +453,29 @@ int Protocol1PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
   int result = COMM_TX_FAIL;
 
   uint8_t txpacket[8]         = {0};
-  uint8_t *rxpacket           = (uint8_t *)malloc(RXPACKET_MAX_LEN);//(length+6);
 
-  if (rxpacket == NULL)
-    return result;
+  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
+    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
+  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
+  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
 
   if (id >= BROADCAST_ID)
   {
-    free(rxpacket);
     return COMM_NOT_AVAILABLE;
   }
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = 4;
   txpacket[PKT_INSTRUCTION]   = INST_READ;
-  txpacket[PKT_PARAMETER0+0]  = (uint8_t)address;
-  txpacket[PKT_PARAMETER0+1]  = (uint8_t)length;
+  txpacket[PKT_PARAMETER0+0]  = static_cast<uint8_t>(address);
+  txpacket[PKT_PARAMETER0+1]  = static_cast<uint8_t>(length);
 
-  result = txRxPacket(port, txpacket, rxpacket, error);
+  result = txRxPacket(port, txpacket, rxpacket.data(), error);
   if (result == COMM_SUCCESS)
   {
     if (error != 0)
     {
-      *error = (uint8_t)rxpacket[PKT_ERROR];
+      *error = rxpacket[PKT_ERROR];
     }
     for (uint16_t s = 0; s < length; s++)
     {
@@ -478,8 +484,6 @@ int Protocol1PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
     //memcpy(data, &rxpacket[PKT_PARAMETER0], length);
   }
 
-  free(rxpacket);
-  //delete[] rxpacket;
   return result;
 }
 
@@ -550,26 +554,23 @@ int Protocol1PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t 
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(length+7);
-  //uint8_t *txpacket           = new uint8_t[length+7];
-
-  if (txpacket == NULL)
-    return result;
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 7))
+    g_txpacket_buffer.reserve(length + 7);
+  g_txpacket_buffer.resize(length + 7);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
   txpacket[PKT_INSTRUCTION]   = INST_WRITE;
-  txpacket[PKT_PARAMETER0]    = (uint8_t)address;
+  txpacket[PKT_PARAMETER0]    = static_cast<uint8_t>(address);
 
   for (uint16_t s = 0; s < length; s++)
     txpacket[PKT_PARAMETER0+1+s] = data[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], data, length);
 
-  result = txPacket(port, txpacket);
+  result = txPacket(port, txpacket.data());
   port->is_using_ = false;
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -577,26 +578,23 @@ int Protocol1PacketHandler::writeTxRx(PortHandler *port, uint8_t id, uint16_t ad
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(length+7); //#6->7
-  //uint8_t *txpacket           = new uint8_t[length+7];
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 7))
+    g_txpacket_buffer.reserve(length + 7);
+  g_txpacket_buffer.resize(length + 7);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
   uint8_t rxpacket[6]         = {0};
-
-  if (txpacket == NULL)
-    return result;
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
   txpacket[PKT_INSTRUCTION]   = INST_WRITE;
-  txpacket[PKT_PARAMETER0]    = (uint8_t)address;
+  txpacket[PKT_PARAMETER0]    = static_cast<uint8_t>(address);
 
   for (uint16_t s = 0; s < length; s++)
     txpacket[PKT_PARAMETER0+1+s] = data[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], data, length);
 
-  result = txRxPacket(port, txpacket, rxpacket, error);
+  result = txRxPacket(port, txpacket.data(), rxpacket, error);
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -637,26 +635,23 @@ int Protocol1PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(length+6);
-  //uint8_t *txpacket           = new uint8_t[length+6];
-
-  if (txpacket == NULL)
-    return result;
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 6))
+    g_txpacket_buffer.reserve(length + 6);
+  g_txpacket_buffer.resize(length + 6);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
   txpacket[PKT_INSTRUCTION]   = INST_REG_WRITE;
-  txpacket[PKT_PARAMETER0]    = (uint8_t)address;
+  txpacket[PKT_PARAMETER0]    = static_cast<uint8_t>(address);
 
   for (uint16_t s = 0; s < length; s++)
     txpacket[PKT_PARAMETER0+1+s] = data[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], data, length);
 
-  result = txPacket(port, txpacket);
+  result = txPacket(port, txpacket.data());
   port->is_using_ = false;
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -664,26 +659,23 @@ int Protocol1PacketHandler::regWriteTxRx(PortHandler *port, uint8_t id, uint16_t
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(length+6);
-  //uint8_t *txpacket           = new uint8_t[length+6];
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 6))
+    g_txpacket_buffer.reserve(length + 6);
+  g_txpacket_buffer.resize(length + 6);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
   uint8_t rxpacket[6]         = {0};
-
-  if (txpacket == NULL)
-    return result;
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
   txpacket[PKT_INSTRUCTION]   = INST_REG_WRITE;
-  txpacket[PKT_PARAMETER0]    = (uint8_t)address;
+  txpacket[PKT_PARAMETER0]    = static_cast<uint8_t>(address);
 
   for (uint16_t s = 0; s < length; s++)
     txpacket[PKT_PARAMETER0+1+s] = data[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], data, length);
 
-  result = txRxPacket(port, txpacket, rxpacket, error);
+  result = txRxPacket(port, txpacket.data(), rxpacket, error);
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -696,12 +688,11 @@ int Protocol1PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(param_length+8);
   // 8: HEADER0 HEADER1 ID LEN INST START_ADDR DATA_LEN ... CHKSUM
-  //uint8_t *txpacket           = new uint8_t[param_length + 8];
-
-  if (txpacket == NULL)
-    return result;
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 8))
+    g_txpacket_buffer.reserve(param_length + 8);
+  g_txpacket_buffer.resize(param_length + 8);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH]        = param_length + 4; // 4: INST START_ADDR DATA_LEN ... CHKSUM
@@ -713,10 +704,8 @@ int Protocol1PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
     txpacket[PKT_PARAMETER0+2+s] = param[s];
   //memcpy(&txpacket[PKT_PARAMETER0+2], param, param_length);
 
-  result = txRxPacket(port, txpacket, 0, 0);
+  result = txRxPacket(port, txpacket.data(), 0, 0);
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 
@@ -724,12 +713,11 @@ int Protocol1PacketHandler::bulkReadTx(PortHandler *port, uint8_t *param, uint16
 {
   int result                 = COMM_TX_FAIL;
 
-  uint8_t *txpacket           = (uint8_t *)malloc(param_length+7);
   // 7: HEADER0 HEADER1 ID LEN INST 0x00 ... CHKSUM
-  //uint8_t *txpacket           = new uint8_t[param_length + 7];
-
-  if (txpacket == NULL)
-    return result;
+  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 7))
+    g_txpacket_buffer.reserve(param_length + 7);
+  g_txpacket_buffer.resize(param_length + 7);
+  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH]        = param_length + 3; // 3: INST 0x00 ... CHKSUM
@@ -740,17 +728,15 @@ int Protocol1PacketHandler::bulkReadTx(PortHandler *port, uint8_t *param, uint16
     txpacket[PKT_PARAMETER0+1+s] = param[s];
   //memcpy(&txpacket[PKT_PARAMETER0+1], param, param_length);
 
-  result = txPacket(port, txpacket);
+  result = txPacket(port, txpacket.data());
   if (result == COMM_SUCCESS)
   {
     int wait_length = 0;
     for (uint16_t i = 0; i < param_length; i += 3)
       wait_length += param[i] + 7;
-    port->setPacketTimeout((uint16_t)wait_length);
+    port->setPacketTimeout(static_cast<uint16_t>(wait_length));
   }
 
-  free(txpacket);
-  //delete[] txpacket;
   return result;
 }
 

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/protocol1_packet_handler.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/protocol1_packet_handler.cpp
@@ -33,11 +33,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-namespace {
-  thread_local std::vector<uint8_t> g_txpacket_buffer;
-  thread_local std::vector<uint8_t> g_rxpacket_buffer;
-}
-
 #define TXPACKET_MAX_LEN    (250)
 #define RXPACKET_MAX_LEN    (250)
 
@@ -422,11 +417,7 @@ int Protocol1PacketHandler::readTx(PortHandler *port, uint8_t id, uint16_t addre
 int Protocol1PacketHandler::readRx(PortHandler *port, uint8_t id, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
-    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
-  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
-  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
+  std::vector<uint8_t> rxpacket(RXPACKET_MAX_LEN);
 
   do {
     result = rxPacket(port, rxpacket.data());
@@ -453,11 +444,7 @@ int Protocol1PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
   int result = COMM_TX_FAIL;
 
   uint8_t txpacket[8]         = {0};
-
-  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
-    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
-  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
-  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
+  std::vector<uint8_t> rxpacket(RXPACKET_MAX_LEN);
 
   if (id >= BROADCAST_ID)
   {
@@ -553,11 +540,7 @@ int Protocol1PacketHandler::read4ByteTxRx(PortHandler *port, uint8_t id, uint16_
 int Protocol1PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data)
 {
   int result                 = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 7))
-    g_txpacket_buffer.reserve(length + 7);
-  g_txpacket_buffer.resize(length + 7);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 7);
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
@@ -577,11 +560,7 @@ int Protocol1PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t 
 int Protocol1PacketHandler::writeTxRx(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                 = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 7))
-    g_txpacket_buffer.reserve(length + 7);
-  g_txpacket_buffer.resize(length + 7);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 7);
   uint8_t rxpacket[6]         = {0};
 
   txpacket[PKT_ID]            = id;
@@ -634,11 +613,7 @@ int Protocol1PacketHandler::write4ByteTxRx(PortHandler *port, uint8_t id, uint16
 int Protocol1PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data)
 {
   int result                 = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 6))
-    g_txpacket_buffer.reserve(length + 6);
-  g_txpacket_buffer.resize(length + 6);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 6);
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH]        = length+3;
@@ -658,11 +633,7 @@ int Protocol1PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16
 int Protocol1PacketHandler::regWriteTxRx(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                 = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 6))
-    g_txpacket_buffer.reserve(length + 6);
-  g_txpacket_buffer.resize(length + 6);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 6);
   uint8_t rxpacket[6]         = {0};
 
   txpacket[PKT_ID]            = id;
@@ -689,10 +660,7 @@ int Protocol1PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
   int result                 = COMM_TX_FAIL;
 
   // 8: HEADER0 HEADER1 ID LEN INST START_ADDR DATA_LEN ... CHKSUM
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 8))
-    g_txpacket_buffer.reserve(param_length + 8);
-  g_txpacket_buffer.resize(param_length + 8);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 8);
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH]        = param_length + 4; // 4: INST START_ADDR DATA_LEN ... CHKSUM
@@ -714,10 +682,7 @@ int Protocol1PacketHandler::bulkReadTx(PortHandler *port, uint8_t *param, uint16
   int result                 = COMM_TX_FAIL;
 
   // 7: HEADER0 HEADER1 ID LEN INST 0x00 ... CHKSUM
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 7))
-    g_txpacket_buffer.reserve(param_length + 7);
-  g_txpacket_buffer.resize(param_length + 7);
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 7);
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH]        = param_length + 3; // 3: INST 0x00 ... CHKSUM

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/protocol2_packet_handler.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/protocol2_packet_handler.cpp
@@ -37,11 +37,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-namespace {
-  thread_local std::vector<uint8_t> g_txpacket_buffer;
-  thread_local std::vector<uint8_t> g_rxpacket_buffer;
-}
-
 #define TXPACKET_MAX_LEN    (1*1024)
 #define RXPACKET_MAX_LEN    (1*1024)
 
@@ -707,11 +702,7 @@ int Protocol2PacketHandler::readTx(PortHandler *port, uint8_t id, uint16_t addre
 int Protocol2PacketHandler::readRx(PortHandler *port, uint8_t id, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-  
-  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
-    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
-  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
-  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
+  std::vector<uint8_t> rxpacket(RXPACKET_MAX_LEN);
   
   do {
     result = rxPacket(port, rxpacket.data());
@@ -737,11 +728,7 @@ int Protocol2PacketHandler::readTxRx(PortHandler *port, uint8_t id, uint16_t add
   int result                  = COMM_TX_FAIL;
 
   uint8_t txpacket[14]        = {0};
-  
-  if (g_rxpacket_buffer.capacity() < RXPACKET_MAX_LEN)
-    g_rxpacket_buffer.reserve(RXPACKET_MAX_LEN);
-  g_rxpacket_buffer.resize(RXPACKET_MAX_LEN);
-  std::vector<uint8_t>& rxpacket = g_rxpacket_buffer;
+  std::vector<uint8_t> rxpacket(RXPACKET_MAX_LEN);
 
   if (id >= BROADCAST_ID)
   {
@@ -840,11 +827,7 @@ int Protocol2PacketHandler::read4ByteTxRx(PortHandler *port, uint8_t id, uint16_
 int Protocol2PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 12 + (length / 3)))
-    g_txpacket_buffer.reserve(length + 12 + (length / 3));
-  g_txpacket_buffer.resize(length + 12 + (length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 12 + (length / 3));
 
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(length+5);
@@ -866,11 +849,7 @@ int Protocol2PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t 
 int Protocol2PacketHandler::writeTxRx(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 12 + (length / 3)))
-    g_txpacket_buffer.reserve(length + 12 + (length / 3));
-  g_txpacket_buffer.resize(length + 12 + (length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 12 + (length / 3));
   uint8_t rxpacket[11]        = {0};
 
   txpacket[PKT_ID]            = id;
@@ -925,11 +904,7 @@ int Protocol2PacketHandler::write4ByteTxRx(PortHandler *port, uint8_t id, uint16
 int Protocol2PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 12 + (length / 3)))
-    g_txpacket_buffer.reserve(length + 12 + (length / 3));
-  g_txpacket_buffer.resize(length + 12 + (length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 12 + (length / 3));
   
   txpacket[PKT_ID]            = id;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(length+5);
@@ -951,11 +926,7 @@ int Protocol2PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16
 int Protocol2PacketHandler::regWriteTxRx(PortHandler *port, uint8_t id, uint16_t address, uint16_t length, uint8_t *data, uint8_t *error)
 {
   int result                  = COMM_TX_FAIL;
-
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(length + 12 + (length / 3)))
-    g_txpacket_buffer.reserve(length + 12 + (length / 3));
-  g_txpacket_buffer.resize(length + 12 + (length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(length + 12 + (length / 3));
   uint8_t rxpacket[11]        = {0};
 
   txpacket[PKT_ID]            = id;
@@ -979,10 +950,7 @@ int Protocol2PacketHandler::syncReadTx(PortHandler *port, uint16_t start_address
   int result                  = COMM_TX_FAIL;
 
   // 14: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 14 + (param_length / 3)))
-    g_txpacket_buffer.reserve(param_length + 14 + (param_length / 3));
-  g_txpacket_buffer.resize(param_length + 14 + (param_length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 14 + (param_length / 3));
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(param_length + 7); // 7: INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
@@ -1009,10 +977,7 @@ int Protocol2PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
   int result                  = COMM_TX_FAIL;
 
   // 14: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 14 + (param_length / 3)))
-    g_txpacket_buffer.reserve(param_length + 14 + (param_length / 3));
-  g_txpacket_buffer.resize(param_length + 14 + (param_length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 14 + (param_length / 3));
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(param_length + 7); // 7: INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
@@ -1037,10 +1002,7 @@ int Protocol2PacketHandler::bulkReadTx(PortHandler *port, uint8_t *param, uint16
   int result                  = COMM_TX_FAIL;
 
   // 10: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST CRC16_L CRC16_H
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 10 + (param_length / 3)))
-    g_txpacket_buffer.reserve(param_length + 10 + (param_length / 3));
-  g_txpacket_buffer.resize(param_length + 10 + (param_length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 10 + (param_length / 3));
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(param_length + 3); // 3: INST CRC16_L CRC16_H
@@ -1068,10 +1030,7 @@ int Protocol2PacketHandler::bulkWriteTxOnly(PortHandler *port, uint8_t *param, u
   int result                  = COMM_TX_FAIL;
 
   // 10: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST CRC16_L CRC16_H
-  if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 10 + (param_length / 3)))
-    g_txpacket_buffer.reserve(param_length + 10 + (param_length / 3));
-  g_txpacket_buffer.resize(param_length + 10 + (param_length / 3));
-  std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+  std::vector<uint8_t> txpacket(param_length + 10 + (param_length / 3));
 
   txpacket[PKT_ID]            = BROADCAST_ID;
   txpacket[PKT_LENGTH_L]      = DXL_LOBYTE(param_length + 3); // 3: INST CRC16_L CRC16_H
@@ -1092,10 +1051,7 @@ int Protocol2PacketHandler::fastSyncReadTx(PortHandler *port, uint16_t start_add
     int result = COMM_TX_FAIL;
 
     // 14: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
-    if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 14 + (param_length / 3)))
-        g_txpacket_buffer.reserve(param_length + 14 + (param_length / 3));
-    g_txpacket_buffer.resize(param_length + 14 + (param_length / 3));
-    std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+    std::vector<uint8_t> txpacket(param_length + 14 + (param_length / 3));
 
     txpacket[PKT_ID]             = BROADCAST_ID;
     txpacket[PKT_LENGTH_L]       = DXL_LOBYTE(param_length + 7); // 7: INST START_ADDR_L START_ADDR_H DATA_LEN_L DATA_LEN_H CRC16_L CRC16_H
@@ -1122,10 +1078,7 @@ int Protocol2PacketHandler::fastBulkReadTx(PortHandler *port, uint8_t *param, ui
     int result = COMM_TX_FAIL;
 
     // 10: HEADER0 HEADER1 HEADER2 RESERVED ID LEN_L LEN_H INST CRC16_L CRC16_H
-    if (g_txpacket_buffer.capacity() < static_cast<size_t>(param_length + 10 + (param_length / 3)))
-        g_txpacket_buffer.reserve(param_length + 10 + (param_length / 3));
-    g_txpacket_buffer.resize(param_length + 10 + (param_length / 3));
-    std::vector<uint8_t>& txpacket = g_txpacket_buffer;
+    std::vector<uint8_t> txpacket(param_length + 10 + (param_length / 3));
 
     txpacket[PKT_ID]          = BROADCAST_ID;
     txpacket[PKT_LENGTH_L]    = DXL_LOBYTE(param_length + 3); // 3: INST CRC16_L CRC16_H

--- a/ros/dynamixel_sdk_custom_interfaces/CHANGELOG.rst
+++ b/ros/dynamixel_sdk_custom_interfaces/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package dynamixel_sdk_custom_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+5.0.0 (2026-04-09)
+------------------
+* Updated package versioning to 5.0.0 to align with the Dynamixel SDK 5.0.0 release
+* Contributors: Hyungyu Kim
+
 4.0.4 (2026-03-27)
 ------------------
 * None

--- a/ros/dynamixel_sdk_custom_interfaces/CHANGELOG.rst
+++ b/ros/dynamixel_sdk_custom_interfaces/CHANGELOG.rst
@@ -2,9 +2,9 @@
 Changelog for package dynamixel_sdk_custom_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-5.0.0 (2026-04-09)
+4.1.0 (2026-04-14)
 ------------------
-* Updated package versioning to 5.0.0 to align with the Dynamixel SDK 5.0.0 release
+* Updated package versioning to 4.1.0 to align with the Dynamixel SDK 4.1.0 release
 * Contributors: Hyungyu Kim
 
 4.0.4 (2026-03-27)

--- a/ros/dynamixel_sdk_custom_interfaces/package.xml
+++ b/ros/dynamixel_sdk_custom_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_sdk_custom_interfaces</name>
-  <version>4.0.4</version>
+  <version>5.0.0</version>
   <description>ROS 2 custom interface examples using ROBOTIS DYNAMIXEL SDK</description>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
   <license>Apache 2.0</license>

--- a/ros/dynamixel_sdk_custom_interfaces/package.xml
+++ b/ros/dynamixel_sdk_custom_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_sdk_custom_interfaces</name>
-  <version>5.0.0</version>
+  <version>4.1.0</version>
   <description>ROS 2 custom interface examples using ROBOTIS DYNAMIXEL SDK</description>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
   <license>Apache 2.0</license>

--- a/ros/dynamixel_sdk_examples/CHANGELOG.rst
+++ b/ros/dynamixel_sdk_examples/CHANGELOG.rst
@@ -2,9 +2,9 @@
 Changelog for package dynamixel_sdk_examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-5.0.0 (2026-04-09)
+4.1.0 (2026-04-14)
 ------------------
-* Updated package versioning to 5.0.0 to align with the Dynamixel SDK 5.0.0 release
+* Updated package versioning to 4.1.0 to align with the Dynamixel SDK 4.1.0 release
 * Contributors: Hyungyu Kim
 
 4.0.4 (2026-03-27)

--- a/ros/dynamixel_sdk_examples/CHANGELOG.rst
+++ b/ros/dynamixel_sdk_examples/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package dynamixel_sdk_examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+5.0.0 (2026-04-09)
+------------------
+* Updated package versioning to 5.0.0 to align with the Dynamixel SDK 5.0.0 release
+* Contributors: Hyungyu Kim
+
 4.0.4 (2026-03-27)
 ------------------
 * None

--- a/ros/dynamixel_sdk_examples/package.xml
+++ b/ros/dynamixel_sdk_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>dynamixel_sdk_examples</name>
-  <version>4.0.4</version>
+  <version>5.0.0</version>
   <description>ROS 2 examples using ROBOTIS DYNAMIXEL SDK</description>
   <license>Apache 2.0</license>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>

--- a/ros/dynamixel_sdk_examples/package.xml
+++ b/ros/dynamixel_sdk_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>dynamixel_sdk_examples</name>
-  <version>5.0.0</version>
+  <version>4.1.0</version>
   <description>ROS 2 examples using ROBOTIS DYNAMIXEL SDK</description>
   <license>Apache 2.0</license>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>


### PR DESCRIPTION
This PR refactors the C++ SDK and ROS 2 C++ wrapper internals to use RAII-based buffer management instead of manual `new[]`/`delete[]` and `malloc`/`free`. Dynamic packet, group read/write, and error buffers are migrated to `std::vector<uint8_t>`, reducing manual memory handling and making ownership clearer across the packet handlers, group handlers, and fast read paths.

In addition, the PR updates package and library versioning for the 5.0.0 release. The standalone C++ library and ROS 2 shared library now declare VERSION 5.0.0 and SOVERSION 3 to reflect the C++ ABI change caused by public class layout updates. Related version metadata was also aligned across C, C++, Python, documentation, Arduino metadata, and ROS package manifests/changelogs.

The PR also revises the standalone C++ uninstall flow. Instead of relying on install_manifest.txt, the uninstall script now removes SDK-owned install paths by name under the configured install prefix, including headers, libraries, CMake package files, and shared data such as the control table.