### PR TITLE
Fix configuration of Linux serial ports

### DIFF
--- a/c++/src/dynamixel_sdk/port_handler_linux.cpp
+++ b/c++/src/dynamixel_sdk/port_handler_linux.cpp
@@ -209,18 +209,31 @@ bool PortHandlerLinux::setupPort(int cflag_baud)
     return false;
   }
 
-  bzero(&newtio, sizeof(newtio)); // clear struct for new port settings
+  if (tcgetattr(socket_fd_, &newtio) != 0)
+  {
+    printf("[PortHandlerLinux::SetupPort] Error getting serial port attributes!\n");
+    closePort();
+    return false;
+  }
 
-  newtio.c_cflag = cflag_baud | CS8 | CLOCAL | CREAD;
+  newtio.c_cflag &= ~(PARENB | CSTOPB | CSIZE | CRTSCTS);
+  newtio.c_cflag |= CS8 | CLOCAL | CREAD;
   newtio.c_iflag = IGNPAR;
   newtio.c_oflag      = 0;
   newtio.c_lflag      = 0;
   newtio.c_cc[VTIME]  = 0;
   newtio.c_cc[VMIN]   = 0;
+  cfsetispeed(&newtio, cflag_baud);
+  cfsetospeed(&newtio, cflag_baud);
 
   // clean the buffer and activate the settings for the port
-  tcflush(socket_fd_, TCIFLUSH);
-  tcsetattr(socket_fd_, TCSANOW, &newtio);
+  tcflush(socket_fd_, TCIOFLUSH);
+  if (tcsetattr(socket_fd_, TCSANOW, &newtio) != 0)
+  {
+    printf("[PortHandlerLinux::SetupPort] Error setting serial port attributes!\n");
+    closePort();
+    return false;
+  }
 
   tx_time_per_byte = (1000.0 / (double)baudrate_) * 10.0;
   return true;

--- a/c/src/dynamixel_sdk/port_handler_linux.c
+++ b/c/src/dynamixel_sdk/port_handler_linux.c
@@ -265,18 +265,31 @@ uint8_t setupPortLinux(int port_num, int cflag_baud)
     return False;
   }
 
-  bzero(&newtio, sizeof(newtio)); // clear struct for new port settings
+  if (tcgetattr(portData[port_num].socket_fd, &newtio) != 0)
+  {
+    printf("[setupPortLinux] Error getting serial port attributes!\n");
+    closePortLinux(port_num);
+    return False;
+  }
 
-  newtio.c_cflag = cflag_baud | CS8 | CLOCAL | CREAD;
+  newtio.c_cflag &= ~(PARENB | CSTOPB | CSIZE | CRTSCTS);
+  newtio.c_cflag |= CS8 | CLOCAL | CREAD;
   newtio.c_iflag = IGNPAR;
   newtio.c_oflag = 0;
   newtio.c_lflag = 0;
   newtio.c_cc[VTIME] = 0;
   newtio.c_cc[VMIN] = 0;
+  cfsetispeed(&newtio, cflag_baud);
+  cfsetospeed(&newtio, cflag_baud);
 
   // clean the buffer and activate the settings for the port
-  tcflush(portData[port_num].socket_fd, TCIFLUSH);
-  tcsetattr(portData[port_num].socket_fd, TCSANOW, &newtio);
+  tcflush(portData[port_num].socket_fd, TCIOFLUSH);
+  if (tcsetattr(portData[port_num].socket_fd, TCSANOW, &newtio) != 0)
+  {
+    printf("[setupPortLinux] Error setting serial port attributes!\n");
+    closePortLinux(port_num);
+    return False;
+  }
 
   portData[port_num].tx_time_per_byte = (1000.0 / (double)portData[port_num].baudrate) * 10.0;
   return True;

--- a/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_linux.cpp
+++ b/ros/dynamixel_sdk/src/dynamixel_sdk/port_handler_linux.cpp
@@ -209,18 +209,31 @@ bool PortHandlerLinux::setupPort(int cflag_baud)
     return false;
   }
 
-  bzero(&newtio, sizeof(newtio)); // clear struct for new port settings
+  if (tcgetattr(socket_fd_, &newtio) != 0)
+  {
+    printf("[PortHandlerLinux::SetupPort] Error getting serial port attributes!\n");
+    closePort();
+    return false;
+  }
 
-  newtio.c_cflag = cflag_baud | CS8 | CLOCAL | CREAD;
+  newtio.c_cflag &= ~(PARENB | CSTOPB | CSIZE | CRTSCTS);
+  newtio.c_cflag |= CS8 | CLOCAL | CREAD;
   newtio.c_iflag = IGNPAR;
   newtio.c_oflag      = 0;
   newtio.c_lflag      = 0;
   newtio.c_cc[VTIME]  = 0;
   newtio.c_cc[VMIN]   = 0;
+  cfsetispeed(&newtio, cflag_baud);
+  cfsetospeed(&newtio, cflag_baud);
 
   // clean the buffer and activate the settings for the port
-  tcflush(socket_fd_, TCIFLUSH);
-  tcsetattr(socket_fd_, TCSANOW, &newtio);
+  tcflush(socket_fd_, TCIOFLUSH);
+  if (tcsetattr(socket_fd_, TCSANOW, &newtio) != 0)
+  {
+    printf("[PortHandlerLinux::SetupPort] Error setting serial port attributes!\n");
+    closePort();
+    return false;
+  }
 
   tx_time_per_byte = (1000.0 / (double)baudrate_) * 10.0;
   return true;


### PR DESCRIPTION
Tested on a Jetson Xavier NX running ros2_control on ROS2 Lyrical container.

Upon initialization, the motors cannot be pinged.

```
[comm_id:XXX][ID:XXX] Request ping - COMM_ERROR : [TxRxResult] There is no status packet!
[dynamixel_hardware_interface]: [comm_id:XX][ID:XX] Cannot connect communication port! :(
```

With this fix, it can be pinged.