### PR TITLE
Fix C port allocation for multiple concurrent devices

### DIFF
--- a/c/src/dynamixel_sdk/port_handler_linux.c
+++ b/c/src/dynamixel_sdk/port_handler_linux.c
@@ -113,7 +113,7 @@ int portHandlerLinux(const char *port_name)
     {
       for (port_num = 0; port_num < g_used_port_num; port_num++)
       {
-        if (portData[port_num].socket_fd != -1)
+        if (portData[port_num].socket_fd == -1)
           break;
       }
 

--- a/c/src/dynamixel_sdk/port_handler_mac.c
+++ b/c/src/dynamixel_sdk/port_handler_mac.c
@@ -80,7 +80,7 @@ int portHandlerMac(const char *port_name)
     {
       for (port_num = 0; port_num < g_used_port_num; port_num++)
       {
-        if (portData[port_num].socket_fd != -1)
+        if (portData[port_num].socket_fd == -1)
           break;
       }
 

--- a/c/src/dynamixel_sdk/port_handler_windows.c
+++ b/c/src/dynamixel_sdk/port_handler_windows.c
@@ -75,7 +75,7 @@ int portHandlerWindows(const char *port_name)
     {
       for (port_num = 0; port_num < g_used_port_num; port_num++)
       {
-        if (portData[port_num].serial_handle != INVALID_HANDLE_VALUE)
+        if (portData[port_num].serial_handle == INVALID_HANDLE_VALUE)
           break;
       }
 


### PR DESCRIPTION
## Summary

- reuse only closed C port slots instead of overwriting an active serial handle/file descriptor
- apply the same correction to the Windows, Linux, and macOS C backends
- preserve the existing behavior for a previously registered device name

Fixes #670.

## Testing

- configured and built the standalone C SDK with CMake on macOS
- opened two independent pseudo-terminal devices through the C API and verified that both ports opened successfully with distinct indices (`0` and `1`)
- `git diff --check`